### PR TITLE
未ログインのトップページでヘッダーが表示されていたので非表示に修正

### DIFF
--- a/apps/frontend/src/components/HeaderWrapper.tsx
+++ b/apps/frontend/src/components/HeaderWrapper.tsx
@@ -12,7 +12,7 @@ export const HeaderWrapper = () => {
   const hideHeaderPaths = ["/login", "/signUp"];
 
   // 指定されたパスではヘッダーを非表示にする
-  const isHiddenPath = hideHeaderPaths.some((path) => pathname?.includes(path));
+  const isHiddenPath = hideHeaderPaths.some((path) => pathname.includes(path));
 
   // トップページかつ未ログイン（または認証判定中）の場合はヘッダーを非表示
   const isWelcomeWithoutLogin =

--- a/apps/frontend/src/components/HeaderWrapper.tsx
+++ b/apps/frontend/src/components/HeaderWrapper.tsx
@@ -2,17 +2,23 @@
 
 import { usePathname } from "next/navigation";
 import { Header } from "@/components/organisms/Header";
+import { useAuth } from "@/hooks/useAuth";
 
 export const HeaderWrapper = () => {
   const pathname = usePathname();
+  const { isAuthenticated, loading } = useAuth();
 
   // ヘッダーを非表示にする画面のパス
   const hideHeaderPaths = ["/login", "/signUp"];
 
   // 指定されたパスではヘッダーを非表示にする
-  const shouldShowHeader = !hideHeaderPaths.some((path) =>
-    pathname?.includes(path)
-  );
+  const isHiddenPath = hideHeaderPaths.some((path) => pathname?.includes(path));
+
+  // トップページかつ未ログイン（または認証判定中）の場合はヘッダーを非表示
+  const isWelcomeWithoutLogin =
+    pathname === "/" && (loading ? true : !isAuthenticated);
+
+  const shouldShowHeader = !(isHiddenPath || isWelcomeWithoutLogin);
 
   if (!shouldShowHeader) {
     return null;


### PR DESCRIPTION
修正前のトップページ
<img width="3028" height="2328" alt="localhost_3000_ (2)" src="https://github.com/user-attachments/assets/41acf6bd-4cab-47db-bc93-284c916cae35" />

修正後のトップページ
<img width="3028" height="2074" alt="localhost_3000_ (1)" src="https://github.com/user-attachments/assets/b00fcbfb-1d76-4ab3-b978-f2dc7fa1624f" />
