### PR TITLE
クエスト詳細画面実装

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -137,11 +137,204 @@ async function main() {
     },
   });
 
+  // ---------------------
+  // 完了済みクエスト作成
+  // ---------------------
+  const completedQuest1 = await prisma.quest.create({
+    data: {
+      title: "React開発スキル向上チャレンジ",
+      description:
+        "Reactを使用したモダンなWebアプリ開発に挑戦。TypeScriptやHooksを学びます。",
+      type: "development",
+      status: "completed",
+      maxParticipants: 12,
+      tags: ["React", "TypeScript", "フロントエンド", "学習"],
+      start_date: new Date("2024-11-01T00:00:00Z"),
+      end_date: new Date("2024-12-31T23:59:59Z"),
+      rewards: {
+        create: {
+          incentive_amount: 50000,
+          point_amount: 500,
+          note: "React開発完了時の報酬",
+        },
+      },
+      quest_participants: {
+        create: [
+          {
+            user: { connect: { id: userTaro.id } },
+            completed_at: new Date("2024-12-15T10:00:00Z"),
+          },
+          {
+            user: { connect: { id: userHanako.id } },
+            completed_at: new Date("2024-12-20T14:30:00Z"),
+          },
+          {
+            user: { connect: { id: userJiro.id } },
+            completed_at: new Date("2024-12-25T09:15:00Z"),
+          },
+        ],
+      },
+    },
+  });
+
+  const completedQuest2 = await prisma.quest.create({
+    data: {
+      title: "データベース設計の基礎を学ぶ",
+      description:
+        "MySQLを使ったデータベース設計とクエリ最適化について学習します。",
+      type: "learning",
+      status: "completed",
+      maxParticipants: 8,
+      tags: ["MySQL", "データベース", "設計", "SQL"],
+      start_date: new Date("2024-10-01T00:00:00Z"),
+      end_date: new Date("2024-11-30T23:59:59Z"),
+      rewards: {
+        create: {
+          incentive_amount: 30000,
+          point_amount: 300,
+          note: "データベース設計完了時の報酬",
+        },
+      },
+      quest_participants: {
+        create: [
+          {
+            user: { connect: { id: userAsato.id } },
+            completed_at: new Date("2024-11-20T16:45:00Z"),
+          },
+          {
+            user: { connect: { id: userTaro.id } },
+            completed_at: new Date("2024-11-25T11:20:00Z"),
+          },
+        ],
+      },
+    },
+  });
+
+  const completedQuest3 = await prisma.quest.create({
+    data: {
+      title: "チーム開発ワークフロー習得",
+      description:
+        "Git、GitHub、CI/CDパイプラインを使ったチーム開発のワークフローを習得します。",
+      type: "development",
+      status: "completed",
+      maxParticipants: 10,
+      tags: ["Git", "GitHub", "CI/CD", "チーム開発"],
+      start_date: new Date("2024-09-01T00:00:00Z"),
+      end_date: new Date("2024-10-31T23:59:59Z"),
+      rewards: {
+        create: {
+          incentive_amount: 40000,
+          point_amount: 400,
+          note: "チーム開発ワークフロー習得完了時の報酬",
+        },
+      },
+      quest_participants: {
+        create: [
+          {
+            user: { connect: { id: userHanako.id } },
+            completed_at: new Date("2024-10-15T13:30:00Z"),
+          },
+          {
+            user: { connect: { id: userJiro.id } },
+            completed_at: new Date("2024-10-20T15:45:00Z"),
+          },
+          {
+            user: { connect: { id: userAsato.id } },
+            completed_at: new Date("2024-10-25T10:15:00Z"),
+          },
+        ],
+      },
+    },
+  });
+
+  // ---------------------
+  // レビューデータ作成
+  // ---------------------
+  // React開発スキル向上チャレンジのレビュー
+  await prisma.review.createMany({
+    data: [
+      {
+        reviewer_id: userTaro.id,
+        guest_id: 1, // 仮の値
+        rating: 5,
+        comment:
+          "ReactとTypeScriptの理解が深まりました！とても勉強になりました。",
+        created_at: new Date("2024-12-16T10:30:00Z"),
+      },
+      {
+        reviewer_id: userHanako.id,
+        guest_id: 1,
+        rating: 4,
+        comment:
+          "Hooksの使い方がよく分かりました。実践的な内容で良かったです。",
+        created_at: new Date("2024-12-21T15:45:00Z"),
+      },
+      {
+        reviewer_id: userJiro.id,
+        guest_id: 1,
+        rating: 5,
+        comment: "モダンなReact開発の流れを学べて大変有意義でした。",
+        created_at: new Date("2024-12-26T09:20:00Z"),
+      },
+    ],
+  });
+
+  // データベース設計の基礎を学ぶのレビュー
+  await prisma.review.createMany({
+    data: [
+      {
+        reviewer_id: userAsato.id,
+        guest_id: 1,
+        rating: 4,
+        comment: "MySQLの設計パターンが理解できました。実務で活かせそうです。",
+        created_at: new Date("2024-11-21T17:00:00Z"),
+      },
+      {
+        reviewer_id: userTaro.id,
+        guest_id: 1,
+        rating: 5,
+        comment:
+          "クエリ最適化の手法が学べて、パフォーマンス改善に役立ちました。",
+        created_at: new Date("2024-11-26T12:15:00Z"),
+      },
+    ],
+  });
+
+  // チーム開発ワークフロー習得のレビュー
+  await prisma.review.createMany({
+    data: [
+      {
+        reviewer_id: userHanako.id,
+        guest_id: 1,
+        rating: 5,
+        comment: "Gitのブランチ戦略やCI/CDの設定方法が詳しく学べました。",
+        created_at: new Date("2024-10-16T14:00:00Z"),
+      },
+      {
+        reviewer_id: userJiro.id,
+        guest_id: 1,
+        rating: 4,
+        comment: "チーム開発のベストプラクティスが理解できました。",
+        created_at: new Date("2024-10-21T16:30:00Z"),
+      },
+      {
+        reviewer_id: userAsato.id,
+        guest_id: 1,
+        rating: 5,
+        comment: "GitHub Actionsを使った自動化の仕組みが勉強になりました。",
+        created_at: new Date("2024-10-26T11:45:00Z"),
+      },
+    ],
+  });
+
   console.log("Seed completed:", {
     quest1: quest1.title,
     quest2: quest2.title,
     quest3: quest3.title,
     quest4: quest4.title,
+    completedQuest1: completedQuest1.title,
+    completedQuest2: completedQuest2.title,
+    completedQuest3: completedQuest3.title,
   });
 }
 

--- a/apps/backend/src/app.ts
+++ b/apps/backend/src/app.ts
@@ -1,6 +1,7 @@
 import express from "express";
 import cors from "cors";
 import questsRouter from "./routes/quests";
+import reviewsRouter from "./routes/reviews";
 
 const app = express();
 const PORT = process.env.PORT || 3001;
@@ -9,6 +10,7 @@ app.use(cors());
 app.use(express.json());
 
 app.use("/api/quests", questsRouter);
+app.use("/api/reviews", reviewsRouter);
 
 app.listen(PORT, () => {
   console.log(`Server is running on http://localhost:${PORT}`);

--- a/apps/backend/src/controllers/reviewController.ts
+++ b/apps/backend/src/controllers/reviewController.ts
@@ -1,0 +1,47 @@
+import { Request, Response } from "express";
+import {
+  getReviewsByQuestIdService,
+  createReviewService,
+} from "../services/reviewService";
+
+// クエストIDでレビュー一覧取得
+export const getReviewsByQuestId = async (req: Request, res: Response) => {
+  const questId = Number(req.params.questId);
+
+  try {
+    const reviews = await getReviewsByQuestIdService(questId);
+    res.json(reviews);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to fetch reviews" });
+  }
+};
+
+// レビュー作成
+export const createReview = async (req: Request, res: Response) => {
+  const questId = Number(req.params.questId);
+  const { reviewer_id, rating, comment } = req.body;
+
+  if (!reviewer_id || !rating) {
+    return res
+      .status(400)
+      .json({ message: "reviewer_id and rating are required" });
+  }
+
+  if (rating < 1 || rating > 5) {
+    return res.status(400).json({ message: "rating must be between 1 and 5" });
+  }
+
+  try {
+    const review = await createReviewService({
+      questId,
+      reviewer_id,
+      rating,
+      comment,
+    });
+    res.status(201).json(review);
+  } catch (error) {
+    console.error(error);
+    res.status(500).json({ message: "Failed to create review" });
+  }
+};

--- a/apps/backend/src/routes/reviews.ts
+++ b/apps/backend/src/routes/reviews.ts
@@ -1,0 +1,12 @@
+import express from "express";
+import {
+  getReviewsByQuestId,
+  createReview,
+} from "../controllers/reviewController";
+
+const router = express.Router();
+
+router.get("/quest/:questId", getReviewsByQuestId); // GET /reviews/quest/:questId
+router.post("/quest/:questId", createReview); // POST /reviews/quest/:questId
+
+export default router;

--- a/apps/backend/src/services/questService.ts
+++ b/apps/backend/src/services/questService.ts
@@ -49,6 +49,11 @@ export const getQuestByIdService = async (id: number) => {
           user: true,
         },
       },
+      _count: {
+        select: {
+          quest_participants: true,
+        },
+      },
     },
   });
 

--- a/apps/backend/src/services/reviewService.ts
+++ b/apps/backend/src/services/reviewService.ts
@@ -1,0 +1,53 @@
+import prisma from "../lib/prisma";
+
+interface CreateReviewData {
+  questId: number;
+  reviewer_id: number;
+  rating: number;
+  comment?: string;
+}
+
+// クエストIDでレビュー一覧取得
+export const getReviewsByQuestIdService = async (questId: number) => {
+  const reviews = await prisma.review.findMany({
+    where: {
+      // 現在のスキーマでは quest_id フィールドがないため、
+      // 一旦すべてのレビューを返す（後でスキーマを修正する必要があります）
+    },
+    include: {
+      reviewer: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+    orderBy: {
+      created_at: "desc",
+    },
+  });
+
+  return reviews;
+};
+
+// レビュー作成
+export const createReviewService = async (data: CreateReviewData) => {
+  const review = await prisma.review.create({
+    data: {
+      reviewer_id: data.reviewer_id,
+      guest_id: 1, // 仮の値（現在のスキーマでは必須）
+      rating: data.rating,
+      comment: data.comment,
+    },
+    include: {
+      reviewer: {
+        select: {
+          id: true,
+          name: true,
+        },
+      },
+    },
+  });
+
+  return review;
+};

--- a/apps/frontend/src/app/quests/[id]/page.tsx
+++ b/apps/frontend/src/app/quests/[id]/page.tsx
@@ -1,0 +1,17 @@
+"use client";
+
+import QuestDetailPage from "@/components/pages/QuestDetailPage";
+import React from "react";
+
+interface QuestPageProps {
+  params: { id: string };
+}
+
+const Page: React.FC<QuestPageProps> = ({ params }) => {
+  const { id } = params;
+
+  // 将来的には id を使って API からクエストデータを取得
+  return <QuestDetailPage questId={id} />;
+};
+
+export default Page;

--- a/apps/frontend/src/app/quests/[id]/page.tsx
+++ b/apps/frontend/src/app/quests/[id]/page.tsx
@@ -4,13 +4,13 @@ import QuestDetailPage from "@/components/pages/QuestDetailPage";
 import React from "react";
 
 interface QuestPageProps {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 const Page: React.FC<QuestPageProps> = ({ params }) => {
-  const { id } = params;
+  const { id } = React.use(params);
 
-  // 将来的には id を使って API からクエストデータを取得
+  // id を使って API からクエストデータを取得
   return <QuestDetailPage questId={id} />;
 };
 

--- a/apps/frontend/src/components/atoms/DifficultyBadge.tsx
+++ b/apps/frontend/src/components/atoms/DifficultyBadge.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface DifficultyBadgeProps {
+  difficulty: "初級" | "中級" | "上級";
+}
+
+const DifficultyBadge: React.FC<DifficultyBadgeProps> = ({ difficulty }) => {
+  const getColor = (difficulty: string) => {
+    switch (difficulty) {
+      case "初級":
+        return "bg-green-500";
+      case "中級":
+        return "bg-yellow-500";
+      case "上級":
+        return "bg-red-500";
+      default:
+        return "bg-gray-500";
+    }
+  };
+
+  return <div className={`w-3 h-3 rounded-full ${getColor(difficulty)}`}></div>;
+};
+
+export default DifficultyBadge;

--- a/apps/frontend/src/components/molecules/QuestCard.tsx
+++ b/apps/frontend/src/components/molecules/QuestCard.tsx
@@ -1,5 +1,9 @@
 import React from "react";
 import StatusRibbon from "../atoms/StatusRibbon";
+import Tag from "../atoms/Tag";
+import DifficultyBadge from "../atoms/DifficultyBadge";
+import QuestTitle from "./QuestTitle";
+import { useRouter } from "next/navigation";
 
 interface Quest {
   id: number;
@@ -8,6 +12,7 @@ interface Quest {
   deadline?: string;
   progress?: number;
   difficulty: "初級" | "中級" | "上級";
+  status: string;
   category: string;
   completedDate?: string;
   appliedDate?: string;
@@ -16,62 +21,47 @@ interface Quest {
 interface QuestCardProps {
   quest: Quest;
   status: "participating" | "completed" | "applied";
+  onActionClick: (quest: Quest) => void;
 }
 
 // クエスト情報のカード
-const QuestCard: React.FC<QuestCardProps> = ({ quest, status }) => {
-  const getDifficultyColor = (difficulty: string): string => {
-    switch (difficulty) {
-      case "初級":
-        return "bg-green-500";
-      case "中級":
-        return "bg-yellow-500";
-      case "上級":
-        return "bg-red-500";
-      default:
-        return "bg-gray-500";
-    }
-  };
+const QuestCard: React.FC<QuestCardProps> = ({ quest, onActionClick }) => {
+  const router = useRouter();
 
-  const formatCurrency = (amount: number): string => {
-    if (typeof amount !== "number" || isNaN(amount)) return "-";
-    return new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-      maximumFractionDigits: 0,
-    }).format(amount);
+  const handleCardClick = () => {
+    router.push(`/quests/${quest.id}`); // 詳細ページへ
   };
 
   return (
-    <div className="bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 border-2 border-amber-200 relative overflow-hidden">
-      <StatusRibbon status={status} />
+    <div
+      className="bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 border-2 border-amber-200 relative overflow-hidden"
+      onClick={handleCardClick}
+    >
+      {/* Status Ribbon */}
+      <StatusRibbon
+        status={
+          quest.status === "active"
+            ? "participating"
+            : quest.status === "completed"
+            ? "completed"
+            : "applied"
+        }
+      />
 
       {/* Difficulty Badge */}
       <div className="absolute top-4 left-4">
-        <div
-          className={`w-3 h-3 rounded-full ${getDifficultyColor(
-            quest.difficulty
-          )}`}
-        ></div>
+        <DifficultyBadge difficulty={quest.difficulty} />
       </div>
 
       <div className="p-6 pt-8">
         {/* Quest Title */}
-        <div className="mb-4">
-          <h3 className="text-lg font-bold text-slate-800 mb-2">
-            {quest.title}
-          </h3>
-          <p className="text-sm text-slate-600">
-            クエストの詳細情報がここに表示されます
-          </p>
-        </div>
+        <QuestTitle
+          title={quest.title}
+          description="クエストの詳細情報がここに表示されます"
+        />
 
         {/* Category Tag */}
-        <div className="flex flex-wrap gap-2 mb-4">
-          <span className="px-2 py-1 bg-slate-200 text-slate-700 text-xs rounded-full font-medium">
-            {quest.category}
-          </span>
-        </div>
+        <Tag>{quest.category}</Tag>
 
         {/* Quest Details */}
         <div className="space-y-2 mb-4 text-sm text-slate-600">
@@ -129,6 +119,10 @@ const QuestCard: React.FC<QuestCardProps> = ({ quest, status }) => {
 
         {/* Action Button */}
         <button
+          onClick={(e) => {
+            e.stopPropagation(); // カードクリックと分離
+            onActionClick(quest);
+          }}
           className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${
             status === "participating"
               ? "bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:from-blue-700 hover:to-blue-800"

--- a/apps/frontend/src/components/molecules/QuestInfo.tsx
+++ b/apps/frontend/src/components/molecules/QuestInfo.tsx
@@ -1,0 +1,79 @@
+"use client";
+import React from "react";
+import { Gift, Users, Calendar } from "lucide-react";
+import Tag from "@/components/atoms/Tag";
+
+interface QuestInfoProps {
+  title: string;
+  description: string;
+  tags: string[];
+  rewards?: {
+    point_amount: number;
+    incentive_amount?: number;
+  };
+  participantsCount: number;
+  maxParticipants: number;
+  endDate: string;
+  difficultyColor: string;
+}
+
+const QuestInfo: React.FC<QuestInfoProps> = ({
+  title,
+  description,
+  tags,
+  rewards,
+  participantsCount,
+  maxParticipants,
+  endDate,
+  difficultyColor,
+}) => {
+  return (
+    <div className="p-6 pt-12">
+      <h1 className="text-2xl font-bold text-slate-800 mb-2">{title}</h1>
+      <p className="text-slate-600 leading-relaxed mb-4">{description}</p>
+
+      <div className="flex flex-wrap gap-2 mb-6">
+        {tags.map((tag, idx) => (
+          <Tag key={idx} color="blue">
+            {tag}
+          </Tag>
+        ))}
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-6 text-sm text-slate-600">
+        <div className="flex justify-between items-center">
+          <span className="flex items-center gap-1">
+            <Gift className="w-4 h-4" /> ポイント報酬
+          </span>
+          <span className="font-semibold text-yellow-600">
+            {rewards?.point_amount || 0}pt
+          </span>
+        </div>
+        {rewards?.incentive_amount && (
+          <div className="flex justify-between items-center">
+            <span>金銭インセンティブ</span>
+            <span className="text-xs text-slate-500">
+              ¥{rewards.incentive_amount.toLocaleString()}
+            </span>
+          </div>
+        )}
+        <div className="flex justify-between items-center">
+          <span className="flex items-center gap-1">
+            <Users className="w-4 h-4" /> 参加者数
+          </span>
+          <span className="font-semibold">
+            {participantsCount} / {maxParticipants}人
+          </span>
+        </div>
+        <div className="flex justify-between items-center">
+          <span className="flex items-center gap-1">
+            <Calendar className="w-4 h-4" /> 期限
+          </span>
+          <span className="font-semibold text-xs">{endDate}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default QuestInfo;

--- a/apps/frontend/src/components/molecules/QuestTitle.tsx
+++ b/apps/frontend/src/components/molecules/QuestTitle.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+
+interface QuestTitleProps {
+  title: string;
+  description?: string;
+}
+
+const QuestTitle: React.FC<QuestTitleProps> = ({ title, description }) => {
+  return (
+    <div className="mb-4">
+      <h3 className="text-lg font-bold text-slate-800 mb-2">{title}</h3>
+      {description && <p className="text-sm text-slate-600">{description}</p>}
+    </div>
+  );
+};
+
+export default QuestTitle;

--- a/apps/frontend/src/components/molecules/ReviewForm.tsx
+++ b/apps/frontend/src/components/molecules/ReviewForm.tsx
@@ -1,0 +1,50 @@
+"use client";
+import React from "react";
+import { Star } from "lucide-react";
+import Button from "@/components/atoms/Button";
+
+interface ReviewFormProps {
+  newReview: { score: number; comment: string };
+  setNewReview: (review: { score: number; comment: string }) => void;
+  onSubmit: () => void;
+}
+
+const ReviewForm: React.FC<ReviewFormProps> = ({
+  newReview,
+  setNewReview,
+  onSubmit,
+}) => {
+  return (
+    <div className="bg-white p-4 rounded-lg border mb-6">
+      <h3 className="font-semibold text-slate-800 mb-3">レビューを投稿</h3>
+      <div className="flex items-center gap-2 mb-3">
+        <span className="text-slate-700">評価:</span>
+        <div className="flex gap-1">
+          {[1, 2, 3, 4, 5].map((star) => (
+            <Star
+              key={star}
+              className={`w-5 h-5 cursor-pointer ${
+                star <= newReview.score
+                  ? "text-yellow-400 fill-current"
+                  : "text-gray-300"
+              }`}
+              onClick={() => setNewReview({ ...newReview, score: star })}
+            />
+          ))}
+        </div>
+        <span className="text-slate-600">({newReview.score})</span>
+      </div>
+      <textarea
+        value={newReview.comment}
+        onChange={(e) =>
+          setNewReview({ ...newReview, comment: e.target.value })
+        }
+        placeholder="レビューコメントを入力してください..."
+        className="w-full px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-green-500 focus:border-green-500 resize-none h-20 mb-3"
+      />
+      <Button onClick={onSubmit}>投稿する</Button>
+    </div>
+  );
+};
+
+export default ReviewForm;

--- a/apps/frontend/src/components/molecules/SubmissionForm.tsx
+++ b/apps/frontend/src/components/molecules/SubmissionForm.tsx
@@ -1,0 +1,30 @@
+"use client";
+import React from "react";
+import Button from "@/components/atoms/Button";
+
+interface SubmissionFormProps {
+  submissionUrl: string;
+  setSubmissionUrl: (url: string) => void;
+  onSubmit: () => void;
+}
+
+const SubmissionForm: React.FC<SubmissionFormProps> = ({
+  submissionUrl,
+  setSubmissionUrl,
+  onSubmit,
+}) => {
+  return (
+    <div className="mb-6 flex gap-2">
+      <input
+        type="url"
+        value={submissionUrl}
+        onChange={(e) => setSubmissionUrl(e.target.value)}
+        placeholder="https://github.com/username/project"
+        className="flex-1 px-3 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+      />
+      <Button onClick={onSubmit}>提出</Button>
+    </div>
+  );
+};
+
+export default SubmissionForm;

--- a/apps/frontend/src/components/organisms/QuestDetailCard.tsx
+++ b/apps/frontend/src/components/organisms/QuestDetailCard.tsx
@@ -1,0 +1,49 @@
+"use client";
+import React from "react";
+import StatusRibbon from "@/components/atoms/StatusRibbon";
+import Button from "@/components/atoms/Button";
+import QuestInfo from "@/components/molecules/QuestInfo";
+
+interface QuestDetailCardProps {
+  status: "participating" | "completed" | "applied";
+  difficultyColor: string;
+  onParticipate: () => void;
+  quest: any;
+}
+
+const QuestDetailCard: React.FC<QuestDetailCardProps> = ({
+  status,
+  difficultyColor,
+  onParticipate,
+  quest,
+}) => {
+  return (
+    <div className="relative bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl border-2 border-amber-200 transition-all duration-300 mb-8">
+      <StatusRibbon status={status} />
+      <div
+        className={`absolute top-4 left-4 w-3 h-3 rounded-full ${difficultyColor}`}
+      />
+      <QuestInfo
+        title={quest.title}
+        description={quest.description}
+        tags={quest.tags}
+        rewards={quest.rewards}
+        participantsCount={quest._count.quest_participants}
+        maxParticipants={quest.maxParticipants}
+        endDate={quest.end_date}
+        difficultyColor={difficultyColor}
+      />
+      <div className="p-6">
+        <Button onClick={onParticipate} active={status === "participating"}>
+          {status === "participating"
+            ? "参加する"
+            : status === "applied"
+            ? "応募済み"
+            : "達成済み"}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default QuestDetailCard;

--- a/apps/frontend/src/components/organisms/ReviewSection.tsx
+++ b/apps/frontend/src/components/organisms/ReviewSection.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import React from "react";
+import { Star, Send } from "lucide-react";
+import ReviewForm from "../molecules/ReviewForm";
+
+export interface Review {
+  id: number;
+  user: string;
+  score: number;
+  comment: string;
+  date: string;
+}
+
+export interface NewReview {
+  score: number;
+  comment: string;
+}
+
+interface ReviewSectionProps {
+  reviews: Review[];
+  newReview: NewReview;
+  setNewReview: (review: NewReview) => void;
+  onSubmit: () => void;
+}
+
+const ReviewSection: React.FC<ReviewSectionProps> = ({
+  reviews,
+  newReview,
+  setNewReview,
+  onSubmit,
+}) => {
+  const averageScore =
+    reviews.length > 0
+      ? reviews.reduce((sum, r) => sum + r.score, 0) / reviews.length
+      : 0;
+
+  return (
+    <div className="bg-gradient-to-br from-green-50 to-green-100 rounded-xl shadow-lg border-2 border-green-200 p-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-xl font-bold text-slate-800">レビュー</h2>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center">
+            {[...Array(5)].map((_, i) => (
+              <Star
+                key={i}
+                className={`w-4 h-4 ${
+                  i < Math.round(averageScore)
+                    ? "text-yellow-400 fill-current"
+                    : "text-gray-300"
+                }`}
+              />
+            ))}
+          </div>
+          <span className="font-semibold text-slate-700">
+            {averageScore.toFixed(1)} ({reviews.length}件)
+          </span>
+        </div>
+      </div>
+
+      {/* 投稿フォーム */}
+      <ReviewForm
+        newReview={newReview}
+        setNewReview={setNewReview}
+        onSubmit={onSubmit}
+      />
+
+      {/* レビュー一覧 */}
+      <div className="max-h-96 overflow-y-auto space-y-4 pr-2">
+        {reviews.map((review) => (
+          <div key={review.id} className="bg-white p-4 rounded-lg border">
+            <div className="flex items-center gap-2 mb-2">
+              <div className="flex">
+                {[...Array(5)].map((_, i) => (
+                  <Star
+                    key={i}
+                    className={`w-4 h-4 ${
+                      i < review.score
+                        ? "text-yellow-400 fill-current"
+                        : "text-gray-300"
+                    }`}
+                  />
+                ))}
+              </div>
+              <span className="text-slate-600 text-sm">{review.user}</span>
+            </div>
+            <p className="text-slate-700">{review.comment}</p>
+            <span className="text-xs text-slate-400">{review.date}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ReviewSection;

--- a/apps/frontend/src/components/pages/QuestDetailPage.tsx
+++ b/apps/frontend/src/components/pages/QuestDetailPage.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import React, { useState } from "react";
+import StatusRibbon from "../atoms/StatusRibbon";
+import Tag from "../atoms/Tag";
+import ReviewSection, { Review, NewReview } from "../organisms/ReviewSection";
+
+interface Quest {
+  id: number;
+  title: string;
+  description: string;
+  reward: number;
+  deadline?: string;
+  progress?: number;
+  difficulty: "初級" | "中級" | "上級";
+  category: string;
+  completedDate?: string;
+  appliedDate?: string;
+}
+
+interface QuestDetailPageProps {
+  questId?: string;
+}
+
+// サンプルクエスト
+const sampleQuest: Quest = {
+  id: 1,
+  title: "React開発スキル向上チャレンジ",
+  description:
+    "Reactを使用したモダンなWebアプリ開発に挑戦。TypeScriptやHooksを学びます。",
+  reward: 500,
+  difficulty: "中級",
+  category: "開発",
+  deadline: "2024-12-31",
+  progress: 100,
+  completedDate: "2024-12-31",
+  appliedDate: "2024-03-01",
+};
+
+// サンプルレビュー5件
+const sampleReviews: Review[] = [
+  {
+    id: 1,
+    user: "Alice",
+    score: 5,
+    comment: "面白かった！",
+    date: "2024-03-10",
+  },
+  {
+    id: 2,
+    user: "Bob",
+    score: 4,
+    comment: "学びが多かったです。",
+    date: "2024-03-11",
+  },
+  {
+    id: 3,
+    user: "Charlie",
+    score: 3,
+    comment: "少し難しかったですが楽しかった。",
+    date: "2024-03-12",
+  },
+  {
+    id: 4,
+    user: "Diana",
+    score: 4,
+    comment: "チーム開発の練習になりました。",
+    date: "2024-03-13",
+  },
+  {
+    id: 5,
+    user: "Eve",
+    score: 5,
+    comment: "TypeScriptの理解が深まりました。",
+    date: "2024-03-14",
+  },
+];
+
+const QuestDetailPage: React.FC<QuestDetailPageProps> = ({ questId }) => {
+  const [reviews, setReviews] = useState<Review[]>(sampleReviews);
+  const [newReview, setNewReview] = useState<NewReview>({
+    score: 0,
+    comment: "",
+  });
+
+  const getDifficultyColor = (difficulty: string): string => {
+    switch (difficulty) {
+      case "初級":
+        return "bg-green-500";
+      case "中級":
+        return "bg-yellow-500";
+      case "上級":
+        return "bg-red-500";
+      default:
+        return "bg-gray-500";
+    }
+  };
+
+  const handleSubmitReview = () => {
+    if (!newReview.comment || newReview.score === 0) return;
+
+    const review: Review = {
+      id: reviews.length + 1,
+      user: "You",
+      score: newReview.score,
+      comment: newReview.comment,
+      date: new Date().toLocaleDateString("ja-JP"),
+    };
+
+    setReviews([review, ...reviews]);
+    setNewReview({ score: 0, comment: "" });
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+      {/* クエスト情報 */}
+      <div className="relative bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg p-6 border-2 border-amber-200 space-y-4">
+        <StatusRibbon status="completed" />
+        <div
+          className={`absolute top-4 left-4 w-3 h-3 rounded-full ${getDifficultyColor(
+            sampleQuest.difficulty
+          )}`}
+        ></div>
+
+        <h1 className="text-2xl font-bold text-slate-800">
+          {sampleQuest.title}
+        </h1>
+        <p className="text-slate-600">{sampleQuest.description}</p>
+        <div className="flex flex-wrap gap-2">
+          <Tag color="blue">{sampleQuest.category}</Tag>
+        </div>
+      </div>
+
+      {/* レビュー */}
+      <ReviewSection
+        reviews={reviews}
+        newReview={newReview}
+        setNewReview={setNewReview}
+        onSubmit={handleSubmitReview}
+      />
+    </div>
+  );
+};
+
+export default QuestDetailPage;

--- a/apps/frontend/src/components/pages/QuestDetailPage.tsx
+++ b/apps/frontend/src/components/pages/QuestDetailPage.tsx
@@ -22,7 +22,7 @@ interface QuestDetailPageProps {
   questId?: string;
 }
 
-// サンプルクエスト
+// サンプルクエスト（完了済み）
 const sampleQuest: Quest = {
   id: 1,
   title: "React開発スキル向上チャレンジ",
@@ -110,6 +110,25 @@ const QuestDetailPage: React.FC<QuestDetailPageProps> = ({ questId }) => {
     setReviews([review, ...reviews]);
     setNewReview({ score: 0, comment: "" });
   };
+
+  // 完了していないクエストの場合はエラー表示
+  if (!sampleQuest.completedDate) {
+    return (
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <div className="bg-red-50 border border-red-200 rounded-xl p-6 text-center">
+          <div className="w-12 h-12 bg-red-500 rounded-full mx-auto mb-4 flex items-center justify-center">
+            <span className="text-white text-2xl">×</span>
+          </div>
+          <h2 className="text-xl font-bold text-red-800 mb-2">
+            レビューできません
+          </h2>
+          <p className="text-red-600">
+            このクエストはまだ完了していません。完了後にレビューを投稿できます。
+          </p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">

--- a/apps/frontend/src/constants/config.ts
+++ b/apps/frontend/src/constants/config.ts
@@ -1,6 +1,20 @@
 import { Clock, CheckCircle, AlertCircle, Crown, Bell } from "lucide-react";
 
 /**
+ * API設定
+ */
+// APIのベースURLを構築（環境変数に/apiが含まれていない場合は追加）
+const baseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001";
+// 末尾の/apiを削除してから、再度/apiを追加することで重複を防ぐ
+const cleanBaseUrl = baseUrl.replace(/\/api\/?$/, "");
+const apiBaseUrl = `${cleanBaseUrl}/api`;
+
+export const API_CONFIG = {
+  /** APIのベースURL */
+  BASE_URL: apiBaseUrl,
+} as const;
+
+/**
  * 難易度別の色設定
  * 初級: 緑、中級: オレンジ、上級: 紫
  */

--- a/apps/frontend/src/services/httpClient.ts
+++ b/apps/frontend/src/services/httpClient.ts
@@ -1,3 +1,5 @@
+import { API_CONFIG } from "../constants/config";
+
 /**
  * - HTTP メソッドのユニオン型
  * - ラッパーのメソッド指定で使用
@@ -25,7 +27,7 @@ export interface RequestOptions<TBody = unknown> {
   init?: Omit<RequestInit, "body" | "method" | "headers">;
 }
 
-const defaultBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL || "";
+const defaultBaseUrl = API_CONFIG.BASE_URL;
 
 /**
  * - クエリオブジェクトを URLSearchParams に変換してクエリ文字列を生成

--- a/apps/frontend/src/services/quest.ts
+++ b/apps/frontend/src/services/quest.ts
@@ -1,0 +1,31 @@
+import { apiClient } from "./httpClient";
+import { Quest } from "../types/quest";
+
+/**
+ * クエスト関連のAPIサービス
+ */
+export const questService = {
+  /**
+   * IDでクエストを取得
+   */
+  getQuestById: async (id: string): Promise<Quest> => {
+    return apiClient.get<Quest>(`/quests/${id}`);
+  },
+
+  /**
+   * 全クエストを取得
+   */
+  getAllQuests: async (params?: {
+    keyword?: string;
+    status?: string;
+  }): Promise<Quest[]> => {
+    return apiClient.get<Quest[]>("/quests", params);
+  },
+
+  /**
+   * クエストのステータスを更新
+   */
+  updateQuestStatus: async (id: string, status: string): Promise<Quest> => {
+    return apiClient.patch<Quest>(`/quests/${id}/status`, { status });
+  },
+};

--- a/apps/frontend/src/services/review.ts
+++ b/apps/frontend/src/services/review.ts
@@ -1,0 +1,42 @@
+import { apiClient } from "./httpClient";
+
+export interface ReviewResponse {
+  id: number;
+  reviewer_id: number;
+  guest_id: number;
+  rating: number;
+  comment: string | null;
+  created_at: string;
+  reviewer: {
+    id: number;
+    name: string;
+  };
+}
+
+export interface CreateReviewRequest {
+  reviewer_id: number;
+  rating: number;
+  comment?: string;
+}
+
+/**
+ * レビュー関連のAPIサービス
+ */
+export const reviewService = {
+  /**
+   * クエストIDでレビュー一覧を取得
+   */
+  getReviewsByQuestId: async (questId: string): Promise<ReviewResponse[]> => {
+    return apiClient.get<ReviewResponse[]>(`/reviews/quest/${questId}`);
+  },
+
+  /**
+   * レビューを作成
+   */
+  createReview: async (
+    questId: string,
+    data: CreateReviewRequest
+  ): Promise<ReviewResponse> => {
+    return apiClient.post<ReviewResponse>(`/reviews/quest/${questId}`, data);
+  },
+};

--- a/apps/frontend/src/types/quest.ts
+++ b/apps/frontend/src/types/quest.ts
@@ -1,0 +1,117 @@
+/**
+ * クエストのステータス
+ */
+export enum QuestStatus {
+  /** アクティブなクエスト */
+  Active = "active",
+  /** 進行中のクエスト */
+  InProgress = "in_progress",
+  /** 停止中のクエスト */
+  Inactive = "inactive",
+  /** 完了したクエスト */
+  Completed = "completed",
+}
+
+/**
+ * クエストの難易度
+ */
+export enum QuestDifficulty {
+  /** 初級 */
+  Beginner = "初級",
+  /** 中級 */
+  Intermediate = "中級",
+  /** 上級 */
+  Advanced = "上級",
+}
+
+/**
+ * クエストのタイプ
+ */
+export enum QuestType {
+  /** 開発系クエスト */
+  Development = "development",
+  /** 学習系クエスト */
+  Learning = "learning",
+  /** チャレンジ系クエスト */
+  Challenge = "challenge",
+}
+
+/**
+ * クエスト参加者情報
+ */
+export interface QuestParticipant {
+  /** 参加ユーザー */
+  user: {
+    /** ユーザー名 */
+    name: string;
+  };
+  /** 参加日時（ISO8601） */
+  joined_at: string;
+  /** 完了日時（ISO8601、省略可） */
+  completed_at?: string;
+}
+
+/**
+ * クエスト情報
+ */
+export interface Quest {
+  /** クエストID */
+  id: number;
+  /** クエストタイトル */
+  title: string;
+  /** クエスト説明 */
+  description: string;
+  /** クエストタイプ */
+  type: QuestType;
+  /** ステータス */
+  status: QuestStatus;
+  /** 開始日（ISO8601） */
+  start_date: string;
+  /** 終了日（ISO8601） */
+  end_date: string;
+  /** 作成日時（ISO8601） */
+  created_at: string;
+  /** 更新日時（ISO8601） */
+  updated_at: string;
+  /** 報酬情報 */
+  rewards: {
+    /** インセンティブ金額 */
+    incentive_amount: string | number;
+    /** ポイント数 */
+    point_amount: number;
+    /** 備考 */
+    note: string;
+  };
+  /** 参加者リスト */
+  quest_participants: QuestParticipant[];
+  /** 参加者数カウント */
+  _count: {
+    /** 参加者数 */
+    quest_participants: number;
+  };
+  /** 最大参加人数 */
+  maxParticipants: number;
+  /** タグリスト */
+  tags: string[];
+  /** 難易度 */
+  difficulty?: QuestDifficulty;
+}
+
+/**
+ * レビュー情報
+ */
+export interface Review {
+  id: number;
+  user: string;
+  score: number;
+  comment: string;
+  date: string;
+}
+
+/**
+ * 新しいレビュー
+ */
+export interface NewReview {
+  score: number;
+  comment: string;
+}


### PR DESCRIPTION
http://localhost:3000/quests/1 の表示
<img width="3028" height="2306" alt="localhost_3000_quests_1" src="https://github.com/user-attachments/assets/da88c2c2-200a-44fc-b0a6-3f5fd18b1f5a" />

[プルリク#14](https://github.com/natsumi-a98/quest-board-app/pull/14)がマージされたら一覧からクリックして詳細に遷移するように修正。