### PR TITLE
refactor: convert mypage service to class

### DIFF
--- a/apps/backend/src/__tests__/services/mypageService.test.ts
+++ b/apps/backend/src/__tests__/services/mypageService.test.ts
@@ -7,14 +7,11 @@ import {
   mockNotification,
 } from "../mocks/mypageDb.mock";
 
-// mypageDbをモック化
-jest.mock("../../dataAccessor/dbAccessor/mypageDb", () => mockMypageDb);
+jest.mock("../../dataAccessor/dbAccessor", () => ({
+  MypageDataAccessor: jest.fn(() => mockMypageDb),
+}));
 
-import {
-  getUserEntries,
-  getUserProfile,
-  getUserNotifications,
-} from "../../services/mypageService";
+import { mypageService } from "../../services/mypageService";
 
 describe("mypageService", () => {
   beforeEach(() => {
@@ -25,7 +22,7 @@ describe("mypageService", () => {
   describe("getUserEntries", () => {
     it("ユーザーの参加中・達成済み・応募中のクエストを取得できる", async () => {
       const userId = 1;
-      const result = await getUserEntries(userId);
+      const result = await mypageService.getUserEntries(userId);
 
       expect(mockMypageDb.fetchUserParticipatingQuests).toHaveBeenCalledWith(
         userId
@@ -67,7 +64,7 @@ describe("mypageService", () => {
       mockMypageDb.fetchUserAppliedQuests.mockResolvedValueOnce([]);
 
       const userId = 1;
-      const result = await getUserEntries(userId);
+      const result = await mypageService.getUserEntries(userId);
 
       expect(result).toEqual({
         participating: [],
@@ -105,7 +102,7 @@ describe("mypageService", () => {
       mockMypageDb.fetchUserAppliedQuests.mockResolvedValueOnce([]);
 
       const userId = 1;
-      const result = await getUserEntries(userId);
+      const result = await mypageService.getUserEntries(userId);
 
       expect(result.participating).toHaveLength(2);
       expect(result.participating[0].title).toBe("クエスト1");
@@ -116,7 +113,7 @@ describe("mypageService", () => {
   describe("getUserProfile", () => {
     it("ユーザー情報を取得できる", async () => {
       const userId = 1;
-      const result = await getUserProfile(userId);
+      const result = await mypageService.getUserProfile(userId);
 
       expect(mockMypageDb.fetchUserById).toHaveBeenCalledWith(userId);
       expect(result).toEqual({
@@ -131,7 +128,7 @@ describe("mypageService", () => {
       mockMypageDb.fetchUserById.mockResolvedValueOnce(null);
 
       const userId = 999;
-      const result = await getUserProfile(userId);
+      const result = await mypageService.getUserProfile(userId);
 
       expect(mockMypageDb.fetchUserById).toHaveBeenCalledWith(userId);
       expect(result).toBeNull();
@@ -147,7 +144,7 @@ describe("mypageService", () => {
       mockMypageDb.fetchUserById.mockResolvedValueOnce(adminUser);
 
       const userId = 1;
-      const result = await getUserProfile(userId);
+      const result = await mypageService.getUserProfile(userId);
 
       expect(result).toEqual({
         id: 1,
@@ -161,7 +158,7 @@ describe("mypageService", () => {
   describe("getUserNotifications", () => {
     it("ユーザーの通知一覧を取得できる", async () => {
       const userId = 1;
-      const result = await getUserNotifications(userId);
+      const result = await mypageService.getUserNotifications(userId);
 
       expect(mockMypageDb.fetchUserNotifications).toHaveBeenCalledWith(userId);
       expect(result).toEqual([
@@ -178,7 +175,7 @@ describe("mypageService", () => {
       mockMypageDb.fetchUserNotifications.mockResolvedValueOnce([]);
 
       const userId = 1;
-      const result = await getUserNotifications(userId);
+      const result = await mypageService.getUserNotifications(userId);
 
       expect(result).toEqual([]);
     });
@@ -200,7 +197,7 @@ describe("mypageService", () => {
       );
 
       const userId = 1;
-      const result = await getUserNotifications(userId);
+      const result = await mypageService.getUserNotifications(userId);
 
       expect(result).toHaveLength(2);
       expect(result[0].isRead).toBe(false);
@@ -228,7 +225,7 @@ describe("mypageService", () => {
       );
 
       const userId = 1;
-      const result = await getUserNotifications(userId);
+      const result = await mypageService.getUserNotifications(userId);
 
       expect(result[0].isRead).toBe(false);
       expect(result[1].isRead).toBe(true);
@@ -240,21 +237,25 @@ describe("mypageService", () => {
       const error = new Error("データベースエラー");
       mockMypageDb.fetchUserParticipatingQuests.mockRejectedValueOnce(error);
 
-      await expect(getUserEntries(1)).rejects.toThrow("データベースエラー");
+      await expect(mypageService.getUserEntries(1)).rejects.toThrow(
+        "データベースエラー"
+      );
     });
 
     it("getUserProfileでエラーが発生した場合、エラーが再スローされる", async () => {
       const error = new Error("データベースエラー");
       mockMypageDb.fetchUserById.mockRejectedValueOnce(error);
 
-      await expect(getUserProfile(1)).rejects.toThrow("データベースエラー");
+      await expect(mypageService.getUserProfile(1)).rejects.toThrow(
+        "データベースエラー"
+      );
     });
 
     it("getUserNotificationsでエラーが発生した場合、エラーが再スローされる", async () => {
       const error = new Error("データベースエラー");
       mockMypageDb.fetchUserNotifications.mockRejectedValueOnce(error);
 
-      await expect(getUserNotifications(1)).rejects.toThrow(
+      await expect(mypageService.getUserNotifications(1)).rejects.toThrow(
         "データベースエラー"
       );
     });
@@ -278,7 +279,7 @@ describe("mypageService", () => {
       mockMypageDb.fetchUserClearedQuests.mockResolvedValueOnce([]);
       mockMypageDb.fetchUserAppliedQuests.mockResolvedValueOnce([]);
 
-      const result = await getUserEntries(1);
+      const result = await mypageService.getUserEntries(1);
 
       expect(result.participating[0]).toEqual({
         id: 10,
@@ -305,7 +306,7 @@ describe("mypageService", () => {
       ]);
       mockMypageDb.fetchUserAppliedQuests.mockResolvedValueOnce([]);
 
-      const result = await getUserEntries(1);
+      const result = await mypageService.getUserEntries(1);
 
       expect(result.completed[0]).toEqual({
         id: 20,
@@ -332,7 +333,7 @@ describe("mypageService", () => {
         customAppliedQuest,
       ]);
 
-      const result = await getUserEntries(1);
+      const result = await mypageService.getUserEntries(1);
 
       expect(result.applied[0]).toEqual({
         id: 30,

--- a/apps/backend/src/controllers/mypageController.ts
+++ b/apps/backend/src/controllers/mypageController.ts
@@ -1,10 +1,6 @@
 // controllers/mypageController.ts
 import { Request, Response } from "express";
-import {
-  getUserEntries,
-  getUserProfile,
-  getUserNotifications,
-} from "../services/mypageService";
+import { mypageService } from "../services/mypageService";
 import { getUserByFirebaseUidService } from "../services/userService";
 
 // 自分の参加中クエスト一覧
@@ -18,7 +14,7 @@ export const getMyEntries = async (req: Request, res: Response) => {
 
     const userId = user.id;
 
-    const entries = await getUserEntries(userId);
+    const entries = await mypageService.getUserEntries(userId);
     res.json(entries);
   } catch (err) {
     console.error(err);
@@ -35,7 +31,7 @@ export const getMyProfile = async (req: Request, res: Response) => {
     const user = await getUserByFirebaseUidService(firebaseUid);
     if (!user) return res.status(404).json({ message: "User not found" });
 
-    const profile = await getUserProfile(user.id);
+    const profile = await mypageService.getUserProfile(user.id);
     res.json(profile ?? {});
   } catch (err) {
     console.error(err);
@@ -52,7 +48,7 @@ export const getMyNotifications = async (req: Request, res: Response) => {
     const user = await getUserByFirebaseUidService(firebaseUid);
     if (!user) return res.status(404).json({ message: "User not found" });
 
-    const notifs = await getUserNotifications(user.id);
+    const notifs = await mypageService.getUserNotifications(user.id);
 
     // 配列で返すように安全策を追加
     res.json(Array.isArray(notifs) ? notifs : []);
@@ -72,7 +68,7 @@ export const getMyClearedQuests = async (req: Request, res: Response) => {
     if (!user) return res.status(404).json({ message: "User not found" });
 
     // getUserEntriesから達成済みクエストを取得
-    const entries = await getUserEntries(user.id);
+    const entries = await mypageService.getUserEntries(user.id);
     res.json(entries.completed || []);
   } catch (err) {
     console.error(err);

--- a/apps/backend/src/dataAccessor/dbAccessor/index.ts
+++ b/apps/backend/src/dataAccessor/dbAccessor/index.ts
@@ -20,3 +20,4 @@ export {
   CreateReviewData,
   UpdateReviewData,
 } from "./Review";
+export { MypageDataAccessor } from "./mypageDb";

--- a/apps/backend/src/dataAccessor/dbAccessor/mypageDb.ts
+++ b/apps/backend/src/dataAccessor/dbAccessor/mypageDb.ts
@@ -1,50 +1,51 @@
-// dbAccesor/mypageDb.ts
 import { prisma } from "../../config/db";
 
-// 参加中クエスト
-export const fetchUserParticipatingQuests = async (userId: number) => {
-  return prisma.questParticipant.findMany({
-    where: {
-      user_id: userId,
-      cleared_at: null, // 未クリア
-    },
-    include: { quest: true },
-  });
-};
+export class MypageDataAccessor {
+  // 参加中クエスト
+  async fetchUserParticipatingQuests(userId: number) {
+    return prisma.questParticipant.findMany({
+      where: {
+        user_id: userId,
+        cleared_at: null,
+      },
+      include: { quest: true },
+    });
+  }
 
-// 達成済みクエスト
-export const fetchUserClearedQuests = async (userId: number) => {
-  return prisma.questParticipant.findMany({
-    where: {
-      user_id: userId,
-      cleared_at: { not: null }, // クリア済み
-    },
-    include: { quest: true },
-  });
-};
+  // 達成済みクエスト
+  async fetchUserClearedQuests(userId: number) {
+    return prisma.questParticipant.findMany({
+      where: {
+        user_id: userId,
+        cleared_at: { not: null },
+      },
+      include: { quest: true },
+    });
+  }
 
-// 応募中クエスト
-export const fetchUserAppliedQuests = async (userId: number) => {
-  return prisma.entry.findMany({
-    where: {
-      user_id: userId,
-      status: "pending", // ステータスは運用に合わせる
-    },
-    include: { quest: true },
-  });
-};
+  // 応募中クエスト
+  async fetchUserAppliedQuests(userId: number) {
+    return prisma.entry.findMany({
+      where: {
+        user_id: userId,
+        status: "pending",
+      },
+      include: { quest: true },
+    });
+  }
 
-// ユーザー情報
-export const fetchUserById = async (userId: number) => {
-  return prisma.user.findUnique({
-    where: { id: userId },
-  });
-};
+  // ユーザー情報
+  async fetchUserById(userId: number) {
+    return prisma.user.findUnique({
+      where: { id: userId },
+    });
+  }
 
-// 通知一覧
-export const fetchUserNotifications = async (userId: number) => {
-  return prisma.notification.findMany({
-    where: { user_id: userId },
-    orderBy: { created_at: "desc" },
-  });
-};
+  // 通知一覧
+  async fetchUserNotifications(userId: number) {
+    return prisma.notification.findMany({
+      where: { user_id: userId },
+      orderBy: { created_at: "desc" },
+    });
+  }
+}

--- a/apps/backend/src/services/mypageService.ts
+++ b/apps/backend/src/services/mypageService.ts
@@ -1,56 +1,59 @@
-// src/services/mypageService.ts
-import {
-  fetchUserParticipatingQuests,
-  fetchUserClearedQuests,
-  fetchUserAppliedQuests,
-  fetchUserById,
-  fetchUserNotifications,
-} from "../dataAccessor/dbAccessor/mypageDb";
+import { MypageDataAccessor } from "../dataAccessor/dbAccessor";
 
-export const getUserEntries = async (userId: number) => {
-  const participating = await fetchUserParticipatingQuests(userId);
-  const cleared = await fetchUserClearedQuests(userId);
-  const applied = await fetchUserAppliedQuests(userId);
+export class MypageService {
+  constructor(private readonly mypageDataAccessor = new MypageDataAccessor()) {}
 
-  return {
-    participating: participating.map((p) => ({
-      id: p.quest.id,
-      title: p.quest.title,
-      status: "participating",
-      joinedAt: p.joined_at,
-    })),
-    completed: cleared.map((c) => ({
-      id: c.quest.id,
-      title: c.quest.title,
-      status: "cleared",
-      clearedAt: c.cleared_at,
-    })),
-    applied: applied.map((a) => ({
-      id: a.quest.id,
-      title: a.quest.title,
-      status: "applied",
-      appliedAt: a.applied_at,
-    })),
-  };
-};
+  async getUserEntries(userId: number) {
+    const participating =
+      await this.mypageDataAccessor.fetchUserParticipatingQuests(userId);
+    const cleared = await this.mypageDataAccessor.fetchUserClearedQuests(userId);
+    const applied = await this.mypageDataAccessor.fetchUserAppliedQuests(userId);
 
-export const getUserProfile = async (userId: number) => {
-  const user = await fetchUserById(userId);
-  if (!user) return null;
-  return {
-    id: user.id,
-    name: user.name,
-    email: user.email,
-    role: user.role,
-  };
-};
+    return {
+      participating: participating.map((p) => ({
+        id: p.quest.id,
+        title: p.quest.title,
+        status: "participating",
+        joinedAt: p.joined_at,
+      })),
+      completed: cleared.map((c) => ({
+        id: c.quest.id,
+        title: c.quest.title,
+        status: "cleared",
+        clearedAt: c.cleared_at,
+      })),
+      applied: applied.map((a) => ({
+        id: a.quest.id,
+        title: a.quest.title,
+        status: "applied",
+        appliedAt: a.applied_at,
+      })),
+    };
+  }
 
-export const getUserNotifications = async (userId: number) => {
-  const notifs = await fetchUserNotifications(userId);
-  return notifs.map((n) => ({
-    id: n.id,
-    message: n.message,
-    isRead: n.is_read,
-    createdAt: n.created_at,
-  }));
-};
+  async getUserProfile(userId: number) {
+    const user = await this.mypageDataAccessor.fetchUserById(userId);
+    if (!user) return null;
+
+    return {
+      id: user.id,
+      name: user.name,
+      email: user.email,
+      role: user.role,
+    };
+  }
+
+  async getUserNotifications(userId: number) {
+    const notifications =
+      await this.mypageDataAccessor.fetchUserNotifications(userId);
+
+    return notifications.map((notification) => ({
+      id: notification.id,
+      message: notification.message,
+      isRead: notification.is_read,
+      createdAt: notification.created_at,
+    }));
+  }
+}
+
+export const mypageService = new MypageService();


### PR DESCRIPTION
## Summary
- `mypageDb` を class ベースの accessor に統一
- `mypageService` を `MypageService` class に変更
- controller / test を新しい service 構成へ追従

## Changes
- `apps/backend/src/dataAccessor/dbAccessor/mypageDb.ts` に `MypageDataAccessor` を追加
- `apps/backend/src/services/mypageService.ts` を class ベースへ変更し、singleton を export
- `apps/backend/src/controllers/mypageController.ts` を `mypageService` 利用に変更
- `apps/backend/src/__tests__/services/mypageService.test.ts` の mock と呼び出し方を更新
- `apps/backend/src/dataAccessor/dbAccessor/index.ts` に accessor export を追加

Closes #23

## Test plan
- [x] `pnpm exec prisma generate --schema apps/backend/prisma/schema.prisma`
- [x] `pnpm --filter backend test -- mypageService`
