### PR TITLE
fix: frontendの.gitignoreでenv除外を有効化する

### DIFF
--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -30,8 +30,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-# .env*
+# env files
+.env*
+!.env*.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## 概要
\`apps/frontend/.gitignore\` の \`.env*\` がコメントアウトされていたため、env ファイルが git 管理対象になる危険があった。

closes #57

## 変更内容
- \`# .env*\` のコメントを解除して env ファイルを確実に除外
- \`!.env*.example\` を追加し、\`.env.local.example\` の追跡は維持

## git rm --cached について
\`apps/frontend/.env.local\` は PR #46（\`docs/setup-kitting-guide\`）にて既に \`git rm --cached\` で Git 追跡から解除済みです。

本 PR ブランチおよび main ブランチ上で追跡状況を確認しました：
\`\`\`bash
$ git ls-files apps/frontend/.env.local
# → 出力なし（追跡されていない）
\`\`\`

そのため本 PR での \`git rm --cached\` は不要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)