### PR TITLE
fix: users/find 系 API に認証ガードを追加

### DIFF
--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -11,8 +11,8 @@ import { authMiddleware, requireAdmin } from "../middlewares/auth.middleware";
 
 const router = express.Router();
 
-router.post("/find", findUserByNameOrEmail); // POST /users/find
-router.post("/get-id", getUserIdByNameOrEmail); // POST /users/get-id
+router.post("/find", authMiddleware, findUserByNameOrEmail); // POST /users/find
+router.post("/get-id", authMiddleware, getUserIdByNameOrEmail); // POST /users/get-id
 router.post("/create", authMiddleware, createUser); // POST /users/create
 router.get("/me", authMiddleware, getCurrentUser); // GET /users/me
 router.get("/all", authMiddleware, requireAdmin, getAllUsers); // GET /users/all

--- a/apps/frontend/src/services/user.ts
+++ b/apps/frontend/src/services/user.ts
@@ -23,7 +23,7 @@ export const userService = {
   findUserByNameOrEmail: async (
     data: FindUserRequest
   ): Promise<UserResponse> => {
-    return apiClient.post<UserResponse, FindUserRequest>("/users/find", data);
+    return authenticatedApiClient.post<UserResponse, FindUserRequest>("/users/find", data);
   },
 
   /**
@@ -32,7 +32,7 @@ export const userService = {
   getUserIdByNameOrEmail: async (
     data: FindUserRequest
   ): Promise<GetUserIdResponse> => {
-    return apiClient.post<GetUserIdResponse, FindUserRequest>(
+    return authenticatedApiClient.post<GetUserIdResponse, FindUserRequest>(
       "/users/get-id",
       data
     );


### PR DESCRIPTION
## Summary

- `POST /users/find` と `POST /users/get-id` に `authMiddleware` を追加
- フロントエンドの `userService` で両エンドポイントの呼び出しを `authenticatedApiClient` に切り替え

認証なしで名前・メールアドレスからユーザー情報を検索できる状態を解消します。

## Test plan

- [ ] 未認証状態で `POST /users/find` を叩くと 401 が返る
- [ ] 未認証状態で `POST /users/get-id` を叩くと 401 が返る
- [ ] 認証済み状態では正常にレスポンスが返る

Closes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)