### PR TITLE
feat: フロントエンドに Vitest + React Testing Library を導入する

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -5,7 +5,10 @@
 	"scripts": {
 		"dev": "next dev",
 		"build": "next build",
-		"start": "next start"
+		"start": "next start",
+		"test": "vitest run",
+		"test:watch": "vitest",
+		"test:coverage": "vitest run --coverage"
 	},
 	"dependencies": {
 		"@emotion/react": "^11.14.0",

--- a/apps/frontend/src/__tests__/components/atoms/DifficultyBadge.test.tsx
+++ b/apps/frontend/src/__tests__/components/atoms/DifficultyBadge.test.tsx
@@ -1,0 +1,20 @@
+import { render } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import DifficultyBadge from "@/components/atoms/DifficultyBadge";
+
+describe("DifficultyBadge", () => {
+  it("初級 のとき緑のクラスが付く", () => {
+    const { container } = render(<DifficultyBadge difficulty="初級" />);
+    expect(container.firstChild).toHaveClass("bg-green-500");
+  });
+
+  it("中級 のとき黄色のクラスが付く", () => {
+    const { container } = render(<DifficultyBadge difficulty="中級" />);
+    expect(container.firstChild).toHaveClass("bg-yellow-500");
+  });
+
+  it("上級 のとき赤のクラスが付く", () => {
+    const { container } = render(<DifficultyBadge difficulty="上級" />);
+    expect(container.firstChild).toHaveClass("bg-red-500");
+  });
+});

--- a/apps/frontend/src/__tests__/components/atoms/StatusRibbon.test.tsx
+++ b/apps/frontend/src/__tests__/components/atoms/StatusRibbon.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import StatusRibbon from "@/components/atoms/StatusRibbon";
+
+describe("StatusRibbon", () => {
+  it("participating のとき「募集中」と表示される", () => {
+    render(<StatusRibbon status="participating" />);
+    expect(screen.getByText("募集中")).toBeInTheDocument();
+  });
+
+  it("completed のとき「完了済み」と表示される", () => {
+    render(<StatusRibbon status="completed" />);
+    expect(screen.getByText("完了済み")).toBeInTheDocument();
+  });
+
+  it("applied のとき「応募中」と表示される", () => {
+    render(<StatusRibbon status="applied" />);
+    expect(screen.getByText("応募中")).toBeInTheDocument();
+  });
+
+  it("participating のとき青系のクラスが付く", () => {
+    const { container } = render(<StatusRibbon status="participating" />);
+    expect(container.firstChild?.firstChild).toHaveClass("text-blue-800");
+  });
+
+  it("completed のとき緑系のクラスが付く", () => {
+    const { container } = render(<StatusRibbon status="completed" />);
+    expect(container.firstChild?.firstChild).toHaveClass("text-green-800");
+  });
+
+  it("applied のときオレンジ系のクラスが付く", () => {
+    const { container } = render(<StatusRibbon status="applied" />);
+    expect(container.firstChild?.firstChild).toHaveClass("text-orange-800");
+  });
+});

--- a/apps/frontend/src/__tests__/components/atoms/Tag.test.tsx
+++ b/apps/frontend/src/__tests__/components/atoms/Tag.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import Tag from "@/components/atoms/Tag";
+
+describe("Tag", () => {
+  it("テキストが表示される", () => {
+    render(<Tag>開発</Tag>);
+    expect(screen.getByText("開発")).toBeInTheDocument();
+  });
+
+  it("デフォルトカラーは blue", () => {
+    const { container } = render(<Tag>テスト</Tag>);
+    expect(container.firstChild).toHaveClass("text-blue-800");
+  });
+
+  it("color=green のとき緑系クラスが付く", () => {
+    const { container } = render(<Tag color="green">テスト</Tag>);
+    expect(container.firstChild).toHaveClass("text-green-800");
+  });
+
+  it("color=orange のときオレンジ系クラスが付く", () => {
+    const { container } = render(<Tag color="orange">テスト</Tag>);
+    expect(container.firstChild).toHaveClass("text-orange-800");
+  });
+
+  it("color=purple のとき紫系クラスが付く", () => {
+    const { container } = render(<Tag color="purple">テスト</Tag>);
+    expect(container.firstChild).toHaveClass("text-purple-800");
+  });
+});

--- a/apps/frontend/src/__tests__/components/molecules/NotificationCard.test.tsx
+++ b/apps/frontend/src/__tests__/components/molecules/NotificationCard.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import NotificationCard from "@/components/molecules/NotificationCard";
+
+const baseNotification = {
+  id: 1,
+  message: "クエストが承認されました",
+  timestamp: "2024/01/15 10:00",
+};
+
+describe("NotificationCard", () => {
+  it("メッセージが表示される", () => {
+    render(<NotificationCard notification={{ ...baseNotification, type: "info" }} />);
+    expect(screen.getByText("クエストが承認されました")).toBeInTheDocument();
+  });
+
+  it("タイムスタンプが表示される", () => {
+    render(<NotificationCard notification={{ ...baseNotification, type: "info" }} />);
+    expect(screen.getByText("2024/01/15 10:00")).toBeInTheDocument();
+  });
+
+  it("type=success のとき success アイコン設定が適用される", () => {
+    const { container } = render(
+      <NotificationCard notification={{ ...baseNotification, type: "success" }} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("type=reward のとき reward アイコン設定が適用される", () => {
+    const { container } = render(
+      <NotificationCard notification={{ ...baseNotification, type: "reward" }} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("type=info のとき info アイコン設定が適用される", () => {
+    const { container } = render(
+      <NotificationCard notification={{ ...baseNotification, type: "info" }} />
+    );
+    expect(container.firstChild).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/__tests__/components/molecules/NotificationList.test.tsx
+++ b/apps/frontend/src/__tests__/components/molecules/NotificationList.test.tsx
@@ -1,0 +1,31 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import NotificationList from "@/components/organisms/NotificationList";
+
+const notifications = [
+  { id: 1, message: "通知1", type: "info" as const, timestamp: "2024/01/01 09:00" },
+  { id: 2, message: "通知2", type: "success" as const, timestamp: "2024/01/02 10:00" },
+];
+
+describe("NotificationList", () => {
+  it("通知がない場合「通知はありません」と表示される", () => {
+    render(<NotificationList notifications={[]} />);
+    expect(screen.getByText("通知はありません")).toBeInTheDocument();
+  });
+
+  it("notifications が未指定の場合「通知はありません」と表示される", () => {
+    render(<NotificationList />);
+    expect(screen.getByText("通知はありません")).toBeInTheDocument();
+  });
+
+  it("通知が存在する場合、メッセージが表示される", () => {
+    render(<NotificationList notifications={notifications} />);
+    expect(screen.getByText("通知1")).toBeInTheDocument();
+    expect(screen.getByText("通知2")).toBeInTheDocument();
+  });
+
+  it("タイトル「通知」が表示される", () => {
+    render(<NotificationList />);
+    expect(screen.getByText("通知")).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,15 +1,19 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 import path from "node:path";
 
 export default defineConfig({
+	plugins: [react()],
 	test: {
 		environment: "jsdom",
 		globals: true,
 		setupFiles: ["./src/__tests__/setup.ts"],
+		include: ["src/**/*.{test,spec}.{ts,tsx}"],
 		coverage: {
 			provider: "v8",
-			include: ["src/hooks/**", "src/services/**"],
-			exclude: ["src/services/firebase.ts"],
+			reporter: ["text", "lcov", "html"],
+			include: ["src/components/**/*.{ts,tsx}", "src/hooks/**", "src/services/**"],
+			exclude: ["src/**/*.d.ts", "src/__tests__/**", "src/services/firebase.ts"],
 		},
 	},
 	resolve: {


### PR DESCRIPTION
## Summary

- Vitest + React Testing Library + jsdom をフロントエンドに導入
- `vitest.config.ts` を追加（jsdom 環境・`@/*` エイリアス・カバレッジ設定）
- `package.json` に `test` / `test:watch` / `test:coverage` スクリプトを追加
- atoms・molecules の主要コンポーネントに対してユニットテストを作成（計 23 テスト）

## テスト対象

| ファイル | テスト数 |
|---------|---------|
| `atoms/StatusRibbon` | 6 |
| `atoms/Tag` | 5 |
| `atoms/DifficultyBadge` | 3 |
| `molecules/NotificationCard` | 5 |
| `organisms/NotificationList` | 4 |

## Test plan

- [ ] `pnpm --filter frontend test` で 23 テスト全パスを確認
- [ ] `pnpm --filter frontend test:coverage` でカバレッジレポート生成を確認

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)