### PR TITLE
Issue 作成ルールと GitHub issue template を追加

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,73 @@
+name: Bug report
+description: 不具合調査や修正の issue を作成する
+title: "[Bug] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: 発生している不具合を簡潔に書いてください。
+      placeholder: 例: ログイン後にプロフィール画面へ遷移できない
+    validations:
+      required: true
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: 発生条件や影響範囲を書いてください。
+      placeholder: 例: 本番環境で Google ログイン時のみ発生し、新規ユーザーが利用開始できない
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps To Reproduce
+      description: 再現手順を書いてください。
+      placeholder: |-
+        例:
+        1. ログイン画面を開く
+        2. Google ログインを選ぶ
+        3. 認証完了後の画面を確認する
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected Behavior
+      description: 本来どうなるべきかを書いてください。
+      placeholder: 例: 認証後にプロフィール画面へ遷移する
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual Behavior
+      description: 実際に何が起きているかを書いてください。
+      placeholder: 例: 404 画面に遷移する
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: 修正完了条件を箇条書きで書いてください。
+      placeholder: |-
+        例:
+        - [ ] 再現手順で 404 が発生しない
+        - [ ] 既存ログイン導線に回帰がない
+    validations:
+      required: true
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: 想定している確認方法があれば書いてください。
+      placeholder: 例: ローカルとステージングで再現手順を実施する
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 関連 issue / PR / ログ / 資料があれば書いてください。
+      placeholder: 例: Sentry URL, #123, PR #456

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature.yml
+++ b/.github/ISSUE_TEMPLATE/feature.yml
@@ -1,0 +1,65 @@
+name: Feature request
+description: 新機能や改善の issue を作成する
+title: "[Feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: 何を実現したい issue かを簡潔に書いてください。
+      placeholder: 例: 投稿一覧に絞り込み UI を追加する
+    validations:
+      required: true
+  - type: textarea
+    id: background
+    attributes:
+      label: Background
+      description: 変更が必要になった背景や現状の問題を書いてください。
+      placeholder: 例: 投稿数が増え、目的の募集を見つけにくくなっている
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope
+      description: 今回の対象範囲を書いてください。
+      placeholder: |-
+        例:
+        - フロントエンドの絞り込みフォーム追加
+        - API のクエリ条件追加
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance Criteria
+      description: 完了条件を箇条書きで書いてください。
+      placeholder: |-
+        例:
+        - [ ] カテゴリで絞り込みできる
+        - [ ] 絞り込み条件が URL に反映される
+    validations:
+      required: true
+  - type: textarea
+    id: out_of_scope
+    attributes:
+      label: Out of Scope
+      description: 今回は対応しない内容があれば書いてください。
+      placeholder: 例: デザインの全面改修は別 issue で扱う
+  - type: textarea
+    id: verification
+    attributes:
+      label: Verification
+      description: 想定している確認方法があれば書いてください。
+      placeholder: |-
+        例:
+        - 絞り込み条件ごとに一覧件数が変わること
+        - クエリ付き URL を再読込しても状態が復元されること
+  - type: textarea
+    id: references
+    attributes:
+      label: References
+      description: 関連 issue / PR / 資料があれば書いてください。
+      placeholder: 例: #123, PR #456, Figma URL

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,14 @@
 - 問題がなければ「追加指摘なし」を明示する。
 - 推測を含む場合は、その旨を明記する。
 
+## Issue
+
+- issue タイトルは対象と目的が判別できる具体的な文言にする。
+- issue 本文には少なくとも `Summary` `Background` `Scope` `Acceptance Criteria` を含める。
+- 実装しない内容や保留事項がある場合は `Out of Scope` または `Notes` を明記する。
+- 検証観点や確認手順が見えている場合は `Verification` を追記する。
+- 関連 issue / PR / 設計資料がある場合は本文から参照できるようにする。
+
 ## PR
 
 - PR 本文には少なくとも `Summary` と `Verification` を含める。


### PR DESCRIPTION
## Summary

- issue 作成ルールを `AGENTS.md` に追記
- GitHub issue template を追加して feature / bug の入力項目を標準化
- 空 issue を禁止して template 利用に統一

## Changes

- `AGENTS.md` に `Issue` セクションを追加
- `.github/ISSUE_TEMPLATE/feature.yml` を追加
- `.github/ISSUE_TEMPLATE/bug.yml` を追加
- `.github/ISSUE_TEMPLATE/config.yml` を追加

## Verification

- [x] `AGENTS.md` の追記内容を確認
- [x] issue template の項目が運用ルールと整合することを確認
- [ ] テスト実行は未実施（ドキュメント / GitHub template 変更のみ）

## Risks / Notes

- GitHub 上で新しい issue template が反映されるのはマージ後
- `.github/PULL_REQUEST_TEMPLATE.md` と `.husky/*` は `origin/main` の既存内容を維持し、今回の PR には含めていない

## Checklist

- [x] 日本語で説明を書いている
- [x] 変更理由が明確
- [x] 影響範囲を確認した
- [x] 実施した検証を記載した
- [x] 実施できなかった検証があれば明記した
