### PR TITLE
fix: frontend の env ファイル管理方針を是正する

### DIFF
--- a/apps/frontend/.gitignore
+++ b/apps/frontend/.gitignore
@@ -30,8 +30,9 @@ yarn-debug.log*
 yarn-error.log*
 .pnpm-debug.log*
 
-# env files (can opt-in for committing if needed)
-# .env*
+# env files
+.env*
+!.env*.example
 
 # vercel
 .vercel


### PR DESCRIPTION
## Summary
- frontend 側の `.gitignore` を修正し、env 実ファイルを除外
- example ファイルベースの運用に合わせて追跡対象を整理

## Related
- #50
- #47

## Verification
- `.gitignore` 変更のためコードテストは未実施

## Notes
- 秘密情報の追跡防止を優先した最小変更