### PR TITLE
docs: CLAUDE を AGENTS 委譲中心に整理

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,58 +1,21 @@
-# Codex Rules
+# Claude Guidance
 
-## General
+このファイルは補助的な互換ガイドです。作業ルールの source of truth は `AGENTS.md` を優先してください。
 
-- 返答、レビューコメント、PR 本文は日本語で記述する。
-- まず既存実装と既存差分を確認し、前提を決め打ちしない。
-- ユーザーが作成した未コミット差分は勝手に戻さない。
-- 破壊的コマンドは、明示的な依頼または承認がある場合のみ実行する。
+## Read First
 
-## Git / Branch
+1. `README.md`
+2. `AGENTS.md`
+3. `CLAUDE.md` は不足分の補助参照として扱う
 
-- issue 対応は原則 `git worktree` で分離する。
-- 作業ブランチは 1 issue / 1 task ごとに切る。
-- 既存 PR がマージ済みの場合は、必要に応じて新しいブランチと PR を作り直す。
-- push 前に upstream との差分と競合有無を確認する。
+## Delegation
 
-## Editing
+- 作業ルール、Issue / PR 運用、検証方針は `AGENTS.md` を参照する
+- このファイルには `AGENTS.md` と重複する詳細ルールを持たせない
+- 互換のために残すが、更新時はまず `AGENTS.md` を修正する
 
-- 手動編集は `apply_patch` を使う。
-- 変更は必要最小限にとどめ、 unrelated な修正を混ぜない。
-- frontend / backend / docs をまたぐ変更は、なぜまたぐ必要があるかを説明する。
-- デフォルトは ASCII を使い、既存ファイルに合わせる場合のみ例外を認める。
+## Notes
 
-## Validation
-
-- 実装後は、可能な範囲でテスト、型チェック、ビルドを実行する。
-- 実装を行った場合は単体テストを追加する。
-- 単体テストのカバレッジは 80% 以上を目標とする。
-- 実行できなかった検証や、既存不具合で失敗した検証は必ず明記する。
-- pre-commit は軽い差分検証に限定する。
-- pre-push は重いローカル検証に使う。
-- CI はリポジトリ全体の最終保証とする。
-
-## Review
-
-- レビューは findings first で書く。
-- 指摘は severity を意識し、根拠ファイルを示す。
-- 問題がなければ「追加指摘なし」を明示する。
-- 推測を含む場合は、その旨を明記する。
-
-## PR
-
-- PR 本文には少なくとも `Summary` と `Verification` を含める。
-- 影響範囲が広い場合は `Risks` か `Notes` を追記する。
-- hook や CI による既存失敗がある場合は、今回変更と既存失敗を切り分けて書く。
-
-## Hooks / CI Responsibilities
-
-- `pre-commit`
-  - formatter / linter
-  - 差分に応じた軽い静的検証
-- `pre-push`
-  - 差分に応じた重いローカル検証
-- `CI`
-  - 全体 lint
-  - 全体 typecheck
-  - build
-  - DB や外部依存を含む検証
+- 返答、レビューコメント、PR 本文は日本語で記述する
+- 既存実装と既存差分を先に確認する
+- issue 単位の branch / worktree 分離、検証、報告方針は `AGENTS.md` に従う


### PR DESCRIPTION
## Summary
- CLAUDE.md を AGENTS.md への委譲中心の内容へ整理
- 重複ルールを削減して source of truth を明確化
- 参照順序を簡潔に明記

## Verification
- `git -C /Users/xxx/Documents/quest-board-app-issue261 diff -- CLAUDE.md`
- CLAUDE.md から AGENTS.md が source of truth だと分かることを確認

## Notes
- docs 変更のみのため、lint / test / build は未実施
- Closes #261