### PR TITLE
docs: README の AI docs 導線を最新化する

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,9 @@ AIエージェント向けの正本は以下です。
 - `docs/architecture.md`: 実装対象の構造、責務、変更時の判断基準
 - `docs/ai-execution.md`: AIの調査、実装、検証フロー
 - `prompt/agent.md`: 他エージェントにも渡せる実行テンプレート
+- `prompt/create_issue.md`: 改善 issue を新規起票するときの補助プロンプト
+- `prompt/modify_issue.md`: 既存 issue を整理、修正するときの補助プロンプト
+- `ai-docs-refactor-prompt.md`: AI 向け docs 自体を見直すときの補助プロンプト
 
 ---
 
@@ -119,7 +122,7 @@ npm install -g pnpm
 ### 1. リポジトリをクローン
 
 ```bash
-git clone https://github.com/natsumi-a98/quest-board-app.git
+git clone https://github.com/Numamura-dev/quest-board-app.git
 cd quest-board-app
 ```
 


### PR DESCRIPTION
## Summary
- README の repo URL を現行リポジトリに更新
- AI docs と補助 prompt の役割を README から辿れるよう整理
- Closes #277

## Verification
- \
- 差分レビューで参照導線と責務分担を確認

## Notes
- docs / template 変更のみのため、lint / test / build は未実施
