### PR TITLE
docs: CLAUDE の補助ガイド導線を整理する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,16 +6,19 @@
 
 1. `README.md`
 2. `AGENTS.md`
-3. `CLAUDE.md` は不足分の補助参照として扱う
+3. `docs/architecture.md`
+4. `docs/ai-execution.md`
+5. `CLAUDE.md` は不足分の補助参照として扱う
 
 ## Delegation
 
 - 作業ルール、Issue / PR 運用、検証方針は `AGENTS.md` を参照する
+- レイヤー責務や変更起点は `docs/architecture.md` を参照する
+- 作業フロー、worktree、検証、報告の流れは `docs/ai-execution.md` を参照する
 - このファイルには `AGENTS.md` と重複する詳細ルールを持たせない
 - 互換のために残すが、更新時はまず `AGENTS.md` を修正する
 
 ## Notes
 
 - 返答、レビューコメント、PR 本文は日本語で記述する
-- 既存実装と既存差分を先に確認する
-- issue 単位の branch / worktree 分離、検証、報告方針は `AGENTS.md` に従う
+- 詳細ルールを増やさず、正本 docs への導線だけを維持する


### PR DESCRIPTION
## Summary
- CLAUDE から architecture / ai-execution へ辿れるよう整理
- 補助ガイドとして残す意図を簡潔化
- Closes #279

## Verification
- \
- 差分レビューで参照導線と責務分担を確認

## Notes
- docs / template 変更のみのため、lint / test / build は未実施
