### PR TITLE
docs: modify_issue prompt の stale refs を除去する

### DIFF
--- a/prompt/modify_issue.md
+++ b/prompt/modify_issue.md
@@ -77,7 +77,8 @@ gh issue view <issue-number>
     .github/ISSUE_TEMPLATE/bug.yml
     .github/ISSUE_TEMPLATE/feature.yml
     .github/ISSUE_TEMPLATE/config.yml
-    .git/refs/heads/docs/issue-pr-rules
+    AGENTS.md
+    README.md
 
 これらから以下を整理してください。
 
@@ -88,6 +89,7 @@ gh issue view <issue-number>
 -   ラベル運用のルール
 -   親Issue / 子Issue / 関連Issue の扱い
 -   粒度に関する暗黙ルール
+-   source-of-truth docs との関係
 
 ------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- 存在しない refs を AGENTS / README 参照へ置換
- 現行 issue 運用で見るべき正本 docs を補足
- Closes #284

## Verification
- \
- 差分レビューで参照導線と責務分担を確認

## Notes
- docs / template 変更のみのため、lint / test / build は未実施
