### PR TITLE
docs: ai-docs-refactor prompt を source-of-truth 参照型へ寄せる

### DIFF
--- a/ai-docs-refactor-prompt.md
+++ b/ai-docs-refactor-prompt.md
@@ -7,11 +7,13 @@
 
 対象ファイル:
 
+- README.md
 - AGENTS.md
-- prompt/agent.md
 - docs/architecture.md
 - docs/ai-execution.md
-- README.md
+- prompt/agent.md
+- CLAUDE.md
+- ai-docs-refactor-prompt.md
 
 目的は **AIエージェントが迷わず実装できるドキュメント構造に整理すること**です。
 
@@ -76,10 +78,9 @@ AIエージェントが使いやすい構造を設計してください。
 repo
 ├ README.md
 ├ AGENTS.md
+├ CLAUDE.md
 ├ docs
 │ ├ architecture.md
-│ ├ api.md
-│ ├ database.md
 │ └ ai-execution.md
 └ prompt
    └ agent.md
@@ -148,16 +149,13 @@ prompt/agent.md
 
 ---
 
-## Step6 改善されたドキュメントテンプレート
+## Step6 変更方針の提示
 
-以下のテンプレートを作成してください。
+必要なファイルだけを最小変更で更新してください。
 
-- AGENTS.md
-- docs/architecture.md
-- docs/ai-execution.md
-- prompt/agent.md
-
-AIがそのまま利用できる形式で作成してください。
+- source-of-truth docs を優先して修正する
+- prompt は docs を参照する形へ寄せる
+- 不要な新規ファイルは増やさない
 
 ---
 


### PR DESCRIPTION
## Summary
- 現行 docs 構成に合わせて対象ファイルと構成例を更新
- 不要なテンプレート生成指示を最小変更方針へ置換
- Closes #285

## Verification
- \
- 差分レビューで参照導線と責務分担を確認

## Notes
- docs / template 変更のみのため、lint / test / build は未実施
