### PR TITLE
feat: フロントエンドにグローバル Error Boundary を追加

### DIFF
--- a/apps/frontend/src/__tests__/components/organisms/AppErrorFallback.test.tsx
+++ b/apps/frontend/src/__tests__/components/organisms/AppErrorFallback.test.tsx
@@ -1,0 +1,49 @@
+import type { AnchorHTMLAttributes } from "react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import AppErrorFallback from "@/components/organisms/AppErrorFallback";
+
+vi.mock("next/link", () => ({
+	default: ({
+		children,
+		href,
+		...props
+	}: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string }) => (
+		<a href={href} {...props}>
+			{children}
+		</a>
+	),
+}));
+
+describe("AppErrorFallback", () => {
+	it("再試行ボタン押下時に onRetry を呼ぶ", () => {
+		const onRetry = vi.fn();
+
+		render(<AppErrorFallback onRetry={onRetry} />);
+
+		fireEvent.click(screen.getByRole("button", { name: "再試行する" }));
+
+		expect(onRetry).toHaveBeenCalledTimes(1);
+	});
+
+	it("トップページへ戻るリンクを表示する", () => {
+		render(<AppErrorFallback />);
+
+		expect(
+			screen.getByRole("link", { name: "トップページへ戻る" }),
+		).toHaveAttribute("href", "/");
+	});
+
+	it("props でタイトルとボタンラベルを上書きできる", () => {
+		render(
+			<AppErrorFallback title="カスタムエラー" retryLabel="再読み込みする" />,
+		);
+
+		expect(
+			screen.getByRole("heading", { name: "カスタムエラー" }),
+		).toBeInTheDocument();
+		expect(
+			screen.getByRole("button", { name: "再読み込みする" }),
+		).toBeInTheDocument();
+	});
+});

--- a/apps/frontend/src/app/error.tsx
+++ b/apps/frontend/src/app/error.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { useEffect } from "react";
+import AppErrorFallback from "@/components/organisms/AppErrorFallback";
+
+type ErrorPageProps = {
+	error: Error & { digest?: string };
+	reset: () => void;
+};
+
+export default function ErrorPage({ error, reset }: ErrorPageProps) {
+	useEffect(() => {
+		console.error("App Router error boundary caught an error", error);
+	}, [error]);
+
+	return (
+		<AppErrorFallback
+			title="ページの表示中にエラーが発生しました"
+			message="一時的な問題の可能性があります。再試行するか、トップページへ戻って操作をやり直してください。"
+			onRetry={reset}
+		/>
+	);
+}

--- a/apps/frontend/src/app/global-error.tsx
+++ b/apps/frontend/src/app/global-error.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { useEffect } from "react";
+import AppErrorFallback from "@/components/organisms/AppErrorFallback";
+
+type GlobalErrorPageProps = {
+	error: Error & { digest?: string };
+	reset: () => void;
+};
+
+export default function GlobalError({ error, reset }: GlobalErrorPageProps) {
+	useEffect(() => {
+		console.error("Global error boundary caught an error", error);
+	}, [error]);
+
+	return (
+		<html lang="ja">
+			<body className="min-h-screen bg-gradient-to-b from-gray-800 to-gray-900 antialiased">
+				<AppErrorFallback
+					title="アプリ全体でエラーが発生しました"
+					message="ページ全体の描画に失敗しました。再試行するか、トップページへ戻って最初から操作をやり直してください。"
+					retryLabel="再読み込みする"
+					onRetry={reset}
+				/>
+			</body>
+		</html>
+	);
+}

--- a/apps/frontend/src/components/organisms/AppErrorFallback.tsx
+++ b/apps/frontend/src/components/organisms/AppErrorFallback.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import Link from "next/link";
+
+type AppErrorFallbackProps = {
+	title?: string;
+	message?: string;
+	retryLabel?: string;
+	onRetry?: () => void;
+};
+
+const AppErrorFallback = ({
+	title = "エラーが発生しました",
+	message = "時間をおいて再度お試しください。解消しない場合はトップページから操作をやり直してください。",
+	retryLabel = "再試行する",
+	onRetry,
+}: AppErrorFallbackProps) => {
+	return (
+		<main
+			className="min-h-[calc(100vh-8rem)] px-4 py-16"
+			aria-labelledby="app-error-title"
+		>
+			<div className="mx-auto flex max-w-xl flex-col items-center rounded-3xl border border-red-200 bg-white/95 p-8 text-center shadow-xl">
+				<span className="mb-4 inline-flex rounded-full bg-red-100 px-3 py-1 text-sm font-semibold text-red-700">
+					Error
+				</span>
+				<h1
+					id="app-error-title"
+					className="mb-3 text-3xl font-bold text-slate-900"
+				>
+					{title}
+				</h1>
+				<p className="mb-8 text-sm leading-7 text-slate-600">{message}</p>
+				<div className="flex w-full flex-col gap-3 sm:flex-row sm:justify-center">
+					<button
+						type="button"
+						onClick={onRetry}
+						className="rounded-xl bg-slate-900 px-5 py-3 text-sm font-semibold text-white transition hover:bg-slate-700"
+					>
+						{retryLabel}
+					</button>
+					<Link
+						href="/"
+						className="rounded-xl border border-slate-300 px-5 py-3 text-sm font-semibold text-slate-700 transition hover:border-slate-400 hover:bg-slate-50"
+					>
+						トップページへ戻る
+					</Link>
+				</div>
+			</div>
+		</main>
+	);
+};
+
+export default AppErrorFallback;


### PR DESCRIPTION
## Summary
- issue #229 として App Router の error.tsx / global-error.tsx を追加
- 再試行導線とトップページ退避導線を持つ共通のエラーフォールバック UI を新設
- フォールバック UI の表示と再試行動作をテストで保証

## Verification
- pnpm --filter frontend test
- pnpm --filter frontend build

## Notes
- pre-commit hook は Biome 通過後、vitest 起動時に optional dependency の @rollup/rollup-darwin-x64 解決で失敗しました
- hook 失敗とは別に、上記コマンドを手動実行してテストと build が通ることを確認しています
- closes #229
