### PR TITLE
feat: 投稿検索に検索履歴の再利用を追加

### DIFF
--- a/apps/frontend/src/__tests__/components/organisms/QuestList.test.tsx
+++ b/apps/frontend/src/__tests__/components/organisms/QuestList.test.tsx
@@ -1,0 +1,130 @@
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+	QuestDifficulty,
+	QuestStatus,
+	QuestType,
+	type Quest,
+} from "@quest-board/types";
+import QuestList from "@/components/organisms/QuestList";
+import { QUEST_SEARCH_HISTORY_KEY } from "@/components/organisms/questSearchHistory";
+
+vi.mock("next/navigation", () => ({
+	useRouter: () => ({
+		push: vi.fn(),
+	}),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+	useAuth: () => ({
+		user: null,
+		isAuthenticated: false,
+		loading: false,
+	}),
+}));
+
+const questServiceMock = vi.hoisted(() => ({
+	getAllQuests: vi.fn(),
+}));
+
+vi.mock("@/services/quest", () => ({
+	questService: questServiceMock,
+}));
+
+vi.mock("@/services/review", () => ({
+	reviewService: {
+		checkUserReviewExists: vi.fn(),
+	},
+}));
+
+vi.mock("@/services/user", () => ({
+	userService: {
+		getCurrentUser: vi.fn(),
+	},
+}));
+
+vi.mock("@/components/organisms/QuestJoinDialog", () => ({
+	default: () => null,
+}));
+
+vi.mock("@/components/organisms/QuestListCard", () => ({
+	__esModule: true,
+	default: ({ quest }: { quest: Quest }) => (
+		<div data-testid="quest-card">{quest.title}</div>
+	),
+}));
+
+const createQuest = (overrides: Partial<Quest>): Quest => ({
+	id: overrides.id ?? 1,
+	title: overrides.title ?? "Quest Title",
+	description: overrides.description ?? "Quest Description",
+	type: overrides.type ?? QuestType.Development,
+	status: overrides.status ?? QuestStatus.Active,
+	start_date: overrides.start_date ?? "2026-03-10T00:00:00.000Z",
+	end_date: overrides.end_date ?? "2026-03-20T00:00:00.000Z",
+	created_at: overrides.created_at ?? "2026-03-01T00:00:00.000Z",
+	updated_at: overrides.updated_at ?? "2026-03-01T00:00:00.000Z",
+	deleted_at: overrides.deleted_at,
+	rewards: overrides.rewards ?? {
+		incentive_amount: 1000,
+		point_amount: 10,
+		note: "reward",
+	},
+	quest_participants: overrides.quest_participants ?? [],
+	_count: overrides._count ?? { quest_participants: 0 },
+	maxParticipants: overrides.maxParticipants ?? 5,
+	tags: overrides.tags ?? [],
+	difficulty: overrides.difficulty ?? QuestDifficulty.Beginner,
+	icon: overrides.icon,
+});
+
+describe("QuestList", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+		questServiceMock.getAllQuests.mockResolvedValue([
+			createQuest({ id: 1, title: "React Quest" }),
+			createQuest({ id: 2, title: "Next Quest" }),
+		]);
+	});
+
+	it("検索欄をクリックすると検索履歴を表示し、選択すると即座に再検索する", async () => {
+		window.localStorage.setItem(
+			QUEST_SEARCH_HISTORY_KEY,
+			JSON.stringify(["Next Quest", "React Quest"]),
+		);
+
+		render(<QuestList />);
+
+		expect(await screen.findAllByTestId("quest-card")).toHaveLength(2);
+
+		const searchInput = screen.getByPlaceholderText("クエストを検索...");
+		fireEvent.focus(searchInput);
+
+		expect(await screen.findByText("検索履歴")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: "Next Quest" }));
+
+		await waitFor(() => {
+			expect(screen.getAllByTestId("quest-card")).toHaveLength(1);
+		});
+
+		expect(screen.getByTestId("quest-card")).toHaveTextContent("Next Quest");
+		expect(searchInput).toHaveValue("Next Quest");
+	});
+
+	it("入力後に blur すると検索履歴を保存する", async () => {
+		render(<QuestList />);
+
+		await screen.findAllByTestId("quest-card");
+
+		const searchInput = screen.getByPlaceholderText("クエストを検索...");
+		fireEvent.change(searchInput, { target: { value: "React Quest" } });
+		fireEvent.blur(searchInput);
+
+		await waitFor(() => {
+			expect(window.localStorage.getItem(QUEST_SEARCH_HISTORY_KEY)).toBe(
+				JSON.stringify(["React Quest"]),
+			);
+		});
+	});
+});

--- a/apps/frontend/src/__tests__/components/organisms/questSearchHistory.test.ts
+++ b/apps/frontend/src/__tests__/components/organisms/questSearchHistory.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+	buildQuestSearchHistory,
+	persistQuestSearchHistory,
+	QUEST_SEARCH_HISTORY_KEY,
+	readQuestSearchHistory,
+} from "@/components/organisms/questSearchHistory";
+
+describe("questSearchHistory", () => {
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
+
+	it("同じ検索語は先頭へ移動しつつ重複を除く", () => {
+		expect(
+			buildQuestSearchHistory(["React", "Next.js", "React Native"], "Next.js"),
+		).toEqual(["Next.js", "React", "React Native"]);
+	});
+
+	it("履歴は最大5件まで保持する", () => {
+		expect(buildQuestSearchHistory(["1", "2", "3", "4", "5"], "6")).toEqual([
+			"6",
+			"1",
+			"2",
+			"3",
+			"4",
+		]);
+	});
+
+	it("localStorage へ保存した履歴を読み戻せる", () => {
+		persistQuestSearchHistory("React");
+		persistQuestSearchHistory("Next.js");
+
+		expect(readQuestSearchHistory()).toEqual(["Next.js", "React"]);
+		expect(window.localStorage.getItem(QUEST_SEARCH_HISTORY_KEY)).toBe(
+			JSON.stringify(["Next.js", "React"]),
+		);
+	});
+});

--- a/apps/frontend/src/components/organisms/QuestList.tsx
+++ b/apps/frontend/src/components/organisms/QuestList.tsx
@@ -25,16 +25,16 @@ import {
 // 一般ユーザーに非表示にするクエストステータス
 const HIDDEN_QUEST_STATUSES: string[] = ["draft", "pending", "inactive"];
 const QUEST_LIST_SKELETON_KEYS = [
-  "skeleton-card-0",
-  "skeleton-card-1",
-  "skeleton-card-2",
-  "skeleton-card-3",
-  "skeleton-card-4",
-  "skeleton-card-5",
+	"skeleton-card-0",
+	"skeleton-card-1",
+	"skeleton-card-2",
+	"skeleton-card-3",
+	"skeleton-card-4",
+	"skeleton-card-5",
 ];
 
 const QuestListSkeleton = () => (
-  <div className="w-full">
+	<div className="w-full">
 		<section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
 			<div className="mb-8 space-y-4 animate-pulse">
 				<div className="flex flex-col sm:flex-row gap-4">
@@ -44,11 +44,11 @@ const QuestListSkeleton = () => (
 			</div>
 
 			<div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-        {QUEST_LIST_SKELETON_KEYS.map((skeletonKey) => (
-          <div
-            key={skeletonKey}
-            className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-800/70 shadow-lg"
-          >
+				{QUEST_LIST_SKELETON_KEYS.map((skeletonKey) => (
+					<div
+						key={skeletonKey}
+						className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-800/70 shadow-lg"
+					>
 						<div className="space-y-4 p-6">
 							<div className="flex items-center justify-between">
 								<div className="h-8 w-8 rounded-full bg-slate-700" />
@@ -160,7 +160,7 @@ const QuestList: React.FC = () => {
 		};
 
 		updateButtonActions();
-  }, [quests, currentUserId]);
+	}, [quests, currentUserId]);
 
 	const getIconComponent = (questType: string) => {
 		switch (questType) {
@@ -198,11 +198,11 @@ const QuestList: React.FC = () => {
 			day: "numeric",
 		});
 
-  const formatCurrency = (amount?: string | number) => {
-    if (!amount) return "-";
-    const numAmount =
-      typeof amount === "string" ? Number.parseFloat(amount) : amount;
-    if (Number.isNaN(numAmount)) return "-";
+	const formatCurrency = (amount?: string | number) => {
+		if (!amount) return "-";
+		const numAmount =
+			typeof amount === "string" ? Number.parseFloat(amount) : amount;
+		if (Number.isNaN(numAmount)) return "-";
 		return new Intl.NumberFormat("ja-JP", {
 			style: "currency",
 			currency: "JPY",
@@ -262,24 +262,24 @@ const QuestList: React.FC = () => {
 		const isParticipant = isUserParticipant(quest);
 		const hasSubmittedReview = await hasUserSubmittedReview(quest);
 
-    if (isParticipant && !hasSubmittedReview) {
-      return {
-        text: "レビューを投稿する",
-        action: () => router.push(`/quests/${quest.id}?action=review`),
-        icon: MessageSquare,
-        className:
-          "bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700",
-      };
-    }
+		if (isParticipant && !hasSubmittedReview) {
+			return {
+				text: "レビューを投稿する",
+				action: () => router.push(`/quests/${quest.id}?action=review`),
+				icon: MessageSquare,
+				className:
+					"bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700",
+			};
+		}
 
-    return {
-      text: "レビューを見る",
-      action: () => router.push(`/quests/${quest.id}`),
-      icon: Eye,
-      className:
-        "bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700",
-    };
-  };
+		return {
+			text: "レビューを見る",
+			action: () => router.push(`/quests/${quest.id}`),
+			icon: Eye,
+			className:
+				"bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700",
+		};
+	};
 
 	const handleJoinQuest = (quest: Quest) => {
 		setSelectedQuest(quest);

--- a/apps/frontend/src/components/organisms/QuestList.tsx
+++ b/apps/frontend/src/components/organisms/QuestList.tsx
@@ -1,254 +1,266 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Search,
-  Sword,
-  Book,
-  Wrench,
-  MessageSquare,
-  Eye,
-} from "lucide-react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { Search, Sword, Book, Wrench, MessageSquare, Eye } from "lucide-react";
 import QuestJoinDialog from "@/components/organisms/QuestJoinDialog";
-import { Quest, QuestDifficulty, QuestType } from "@quest-board/types";
+import { type Quest, QuestDifficulty, QuestType } from "@quest-board/types";
 import { questService } from "@/services/quest";
 import { reviewService } from "@/services/review";
 import { userService } from "@/services/user";
 import { useAuth } from "@/hooks/useAuth";
 import { useRouter } from "next/navigation";
 import QuestListCard, {
-  type CompletedQuestButtonAction,
+	type CompletedQuestButtonAction,
 } from "@/components/organisms/QuestListCard";
 import {
-  filterQuests,
-  getSuggestedQuests,
+	filterQuests,
+	getSuggestedQuests,
 } from "@/components/organisms/questListFilters";
+import {
+	persistQuestSearchHistory,
+	readQuestSearchHistory,
+} from "@/components/organisms/questSearchHistory";
 
 // 一般ユーザーに非表示にするクエストステータス
 const HIDDEN_QUEST_STATUSES: string[] = ["draft", "pending", "inactive"];
+const QUEST_LIST_SKELETON_KEYS = [
+  "skeleton-card-0",
+  "skeleton-card-1",
+  "skeleton-card-2",
+  "skeleton-card-3",
+  "skeleton-card-4",
+  "skeleton-card-5",
+];
 
 const QuestListSkeleton = () => (
   <div className="w-full">
-    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
-      <div className="mb-8 space-y-4 animate-pulse">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="h-12 flex-1 rounded-lg bg-slate-700/80" />
-          <div className="h-12 w-full rounded-lg bg-slate-700/70 sm:w-56" />
-        </div>
-      </div>
+		<section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
+			<div className="mb-8 space-y-4 animate-pulse">
+				<div className="flex flex-col sm:flex-row gap-4">
+					<div className="h-12 flex-1 rounded-lg bg-slate-700/80" />
+					<div className="h-12 w-full rounded-lg bg-slate-700/70 sm:w-56" />
+				</div>
+			</div>
 
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, index) => (
+			<div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+        {QUEST_LIST_SKELETON_KEYS.map((skeletonKey) => (
           <div
-            key={`skeleton-card-${index}`}
+            key={skeletonKey}
             className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-800/70 shadow-lg"
           >
-            <div className="space-y-4 p-6">
-              <div className="flex items-center justify-between">
-                <div className="h-8 w-8 rounded-full bg-slate-700" />
-                <div className="h-6 w-24 rounded-full bg-slate-700" />
-              </div>
-              <div className="space-y-2">
-                <div className="h-6 w-3/4 rounded bg-slate-600" />
-                <div className="h-4 w-full rounded bg-slate-700" />
-                <div className="h-4 w-5/6 rounded bg-slate-700" />
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <div className="h-6 w-16 rounded-full bg-slate-700" />
-                <div className="h-6 w-20 rounded-full bg-slate-700" />
-                <div className="h-6 w-14 rounded-full bg-slate-700" />
-              </div>
-              <div className="grid grid-cols-2 gap-3 pt-3">
-                <div className="h-16 rounded-2xl bg-slate-700/80" />
-                <div className="h-16 rounded-2xl bg-slate-700/80" />
-              </div>
-              <div className="h-11 rounded-2xl bg-slate-600/80" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  </div>
+						<div className="space-y-4 p-6">
+							<div className="flex items-center justify-between">
+								<div className="h-8 w-8 rounded-full bg-slate-700" />
+								<div className="h-6 w-24 rounded-full bg-slate-700" />
+							</div>
+							<div className="space-y-2">
+								<div className="h-6 w-3/4 rounded bg-slate-600" />
+								<div className="h-4 w-full rounded bg-slate-700" />
+								<div className="h-4 w-5/6 rounded bg-slate-700" />
+							</div>
+							<div className="flex flex-wrap gap-2">
+								<div className="h-6 w-16 rounded-full bg-slate-700" />
+								<div className="h-6 w-20 rounded-full bg-slate-700" />
+								<div className="h-6 w-14 rounded-full bg-slate-700" />
+							</div>
+							<div className="grid grid-cols-2 gap-3 pt-3">
+								<div className="h-16 rounded-2xl bg-slate-700/80" />
+								<div className="h-16 rounded-2xl bg-slate-700/80" />
+							</div>
+							<div className="h-11 rounded-2xl bg-slate-600/80" />
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
+	</div>
 );
 
 const QuestList: React.FC = () => {
-  const [quests, setQuests] = useState<Quest[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedFilter, setSelectedFilter] = useState("all");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [startDateFilter, setStartDateFilter] = useState("");
-  const [endDateFilter, setEndDateFilter] = useState("");
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [selectedQuest, setSelectedQuest] = useState<Quest | null>(null);
-  const [buttonActions, setButtonActions] = useState<
-    Map<number, CompletedQuestButtonAction>
-  >(new Map());
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
-  const searchContainerRef = useRef<HTMLDivElement | null>(null);
-  const { user, isAuthenticated } = useAuth();
-  const router = useRouter();
+	const [quests, setQuests] = useState<Quest[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [selectedFilter, setSelectedFilter] = useState("all");
+	const [searchQuery, setSearchQuery] = useState("");
+	const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+	const [showSuggestions, setShowSuggestions] = useState(false);
+	const [startDateFilter, setStartDateFilter] = useState("");
+	const [endDateFilter, setEndDateFilter] = useState("");
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [selectedQuest, setSelectedQuest] = useState<Quest | null>(null);
+	const [buttonActions, setButtonActions] = useState<
+		Map<number, CompletedQuestButtonAction>
+	>(new Map());
+	const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+	const [searchHistory, setSearchHistory] = useState<string[]>([]);
+	const searchContainerRef = useRef<HTMLDivElement | null>(null);
+	const { user, isAuthenticated } = useAuth();
+	const router = useRouter();
 
-  useEffect(() => {
-    const fetchQuests = async () => {
-      try {
-        const data = await questService.getAllQuests();
-        setQuests(data);
-      } catch (err) {
-        console.error(err);
-        setQuests([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchQuests();
-  }, []);
+	useEffect(() => {
+		const fetchQuests = async () => {
+			try {
+				const data = await questService.getAllQuests();
+				setQuests(data);
+			} catch (err) {
+				console.error(err);
+				setQuests([]);
+			} finally {
+				setLoading(false);
+			}
+		};
+		fetchQuests();
+	}, []);
 
-  useEffect(() => {
-    const timerId = window.setTimeout(() => {
-      setDebouncedSearchQuery(searchQuery.trim());
-    }, 200);
+	useEffect(() => {
+		const timerId = window.setTimeout(() => {
+			setDebouncedSearchQuery(searchQuery.trim());
+		}, 200);
 
-    return () => window.clearTimeout(timerId);
-  }, [searchQuery]);
+		return () => window.clearTimeout(timerId);
+	}, [searchQuery]);
 
-  // ユーザーIDを動的に取得
-  useEffect(() => {
-    const fetchUserId = async () => {
-      if (!user || !isAuthenticated) {
-        setCurrentUserId(null);
-        return;
-      }
+	useEffect(() => {
+		setSearchHistory(readQuestSearchHistory());
+	}, []);
 
-      try {
-        const userData = await userService.getCurrentUser();
-        setCurrentUserId(userData.id);
-      } catch (error) {
-        console.error("QuestList: ユーザーID取得エラー:", error);
-        setCurrentUserId(null);
-      }
-    };
+	// ユーザーIDを動的に取得
+	useEffect(() => {
+		const fetchUserId = async () => {
+			if (!user || !isAuthenticated) {
+				setCurrentUserId(null);
+				return;
+			}
 
-    fetchUserId();
-  }, [user, isAuthenticated]);
+			try {
+				const userData = await userService.getCurrentUser();
+				setCurrentUserId(userData.id);
+			} catch (error) {
+				console.error("QuestList: ユーザーID取得エラー:", error);
+				setCurrentUserId(null);
+			}
+		};
 
-  // クエストデータが取得されたら、各クエストのボタンアクションを決定
-  useEffect(() => {
-    const updateButtonActions = async () => {
-      if (quests.length === 0 || !currentUserId) return;
+		fetchUserId();
+	}, [user, isAuthenticated]);
 
-      const newButtonActions = new Map<number, CompletedQuestButtonAction>();
-      for (const quest of quests) {
-        if (quest.status === "completed") {
-          const action = await getCompletedQuestButtonAction(quest);
-          newButtonActions.set(quest.id, action);
-        }
-      }
-      setButtonActions(newButtonActions);
-    };
+	// クエストデータが取得されたら、各クエストのボタンアクションを決定
+	useEffect(() => {
+		const updateButtonActions = async () => {
+			if (quests.length === 0 || !currentUserId) return;
 
-    updateButtonActions();
-  }, [quests, user, isAuthenticated, currentUserId]);
+			const newButtonActions = new Map<number, CompletedQuestButtonAction>();
+			for (const quest of quests) {
+				if (quest.status === "completed") {
+					const action = await getCompletedQuestButtonAction(quest);
+					newButtonActions.set(quest.id, action);
+				}
+			}
+			setButtonActions(newButtonActions);
+		};
 
-  const getIconComponent = (questType: string) => {
-    switch (questType) {
-      case QuestType.Development:
-        return <Wrench className="w-6 h-6" />;
-      case QuestType.Learning:
-        return <Book className="w-6 h-6" />;
-      case QuestType.Challenge:
-      case QuestType.Planning:
-      case QuestType.Maintenance:
-      case QuestType.Design:
-        return <Sword className="w-6 h-6" />;
-      default:
-        return <Sword className="w-6 h-6" />;
-    }
-  };
+		updateButtonActions();
+  }, [quests, currentUserId]);
 
-  const getDifficultyColor = (difficulty?: QuestDifficulty) => {
-    switch (difficulty) {
-      case QuestDifficulty.Beginner:
-        return "bg-green-500";
-      case QuestDifficulty.Intermediate:
-        return "bg-yellow-500";
-      case QuestDifficulty.Advanced:
-        return "bg-red-500";
-      default:
-        return "bg-gray-500";
-    }
-  };
+	const getIconComponent = (questType: string) => {
+		switch (questType) {
+			case QuestType.Development:
+				return <Wrench className="w-6 h-6" />;
+			case QuestType.Learning:
+				return <Book className="w-6 h-6" />;
+			case QuestType.Challenge:
+			case QuestType.Planning:
+			case QuestType.Maintenance:
+			case QuestType.Design:
+				return <Sword className="w-6 h-6" />;
+			default:
+				return <Sword className="w-6 h-6" />;
+		}
+	};
 
-  const formatDate = (dateString: string) =>
-    new Date(dateString).toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+	const getDifficultyColor = (difficulty?: QuestDifficulty) => {
+		switch (difficulty) {
+			case QuestDifficulty.Beginner:
+				return "bg-green-500";
+			case QuestDifficulty.Intermediate:
+				return "bg-yellow-500";
+			case QuestDifficulty.Advanced:
+				return "bg-red-500";
+			default:
+				return "bg-gray-500";
+		}
+	};
+
+	const formatDate = (dateString: string) =>
+		new Date(dateString).toLocaleDateString("ja-JP", {
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		});
 
   const formatCurrency = (amount?: string | number) => {
     if (!amount) return "-";
-    const numAmount = typeof amount === "string" ? parseFloat(amount) : amount;
-    if (isNaN(numAmount)) return "-";
-    return new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-      maximumFractionDigits: 0,
-    }).format(numAmount);
-  };
+    const numAmount =
+      typeof amount === "string" ? Number.parseFloat(amount) : amount;
+    if (Number.isNaN(numAmount)) return "-";
+		return new Intl.NumberFormat("ja-JP", {
+			style: "currency",
+			currency: "JPY",
+			maximumFractionDigits: 0,
+		}).format(numAmount);
+	};
 
-  // ユーザーがクエストに参加しているかどうかを判定
-  const isUserParticipant = (quest: Quest): boolean => {
-    if (!user || !isAuthenticated || !currentUserId) return false;
+	// ユーザーがクエストに参加しているかどうかを判定
+	const isUserParticipant = (quest: Quest): boolean => {
+		if (!user || !isAuthenticated || !currentUserId) return false;
 
-    const isParticipant =
-      quest.quest_participants?.some((participant) => {
-        return participant.user.id === currentUserId;
-      }) || false;
+		const isParticipant =
+			quest.quest_participants?.some((participant) => {
+				return participant.user.id === currentUserId;
+			}) || false;
 
-    return isParticipant;
-  };
+		return isParticipant;
+	};
 
-  // ユーザーがレビューを投稿済みかどうかを判定
-  const hasUserSubmittedReview = async (quest: Quest): Promise<boolean> => {
-    if (!user || !isAuthenticated || !currentUserId) return false;
+	// ユーザーがレビューを投稿済みかどうかを判定
+	const hasUserSubmittedReview = async (quest: Quest): Promise<boolean> => {
+		if (!user || !isAuthenticated || !currentUserId) return false;
 
-    const participant = quest.quest_participants?.find((p) => {
-      return p.user.id === currentUserId;
-    });
+		const participant = quest.quest_participants?.find((p) => {
+			return p.user.id === currentUserId;
+		});
 
-    if (!participant) return false;
+		if (!participant) return false;
 
-    // 実際のAPIを呼び出してレビュー投稿状況を確認
-    try {
-      const response = await reviewService.checkUserReviewExists(
-        currentUserId.toString(),
-        quest.id.toString()
-      );
-      return response.exists;
-    } catch (error) {
-      console.error("レビュー投稿状況確認エラー:", error);
-      return false;
-    }
-  };
+		// 実際のAPIを呼び出してレビュー投稿状況を確認
+		try {
+			const response = await reviewService.checkUserReviewExists(
+				currentUserId.toString(),
+				quest.id.toString(),
+			);
+			return response.exists;
+		} catch (error) {
+			console.error("レビュー投稿状況確認エラー:", error);
+			return false;
+		}
+	};
 
-  // 完了したクエストのボタンアクションを決定
-  const getCompletedQuestButtonAction = async (
-    quest: Quest
-  ): Promise<CompletedQuestButtonAction> => {
-    if (!isAuthenticated) {
-      return {
-        text: "レビューを見る",
-        action: () => router.push(`/quests/${quest.id}`),
-        icon: Eye,
-        className:
-          "bg-gradient-to-r from-gray-500 to-gray-600 text-white hover:from-gray-600 hover:to-gray-700",
-      };
-    }
+	// 完了したクエストのボタンアクションを決定
+	const getCompletedQuestButtonAction = async (
+		quest: Quest,
+	): Promise<CompletedQuestButtonAction> => {
+		if (!isAuthenticated) {
+			return {
+				text: "レビューを見る",
+				action: () => router.push(`/quests/${quest.id}`),
+				icon: Eye,
+				className:
+					"bg-gradient-to-r from-gray-500 to-gray-600 text-white hover:from-gray-600 hover:to-gray-700",
+			};
+		}
 
-    const isParticipant = isUserParticipant(quest);
-    const hasSubmittedReview = await hasUserSubmittedReview(quest);
+		const isParticipant = isUserParticipant(quest);
+		const hasSubmittedReview = await hasUserSubmittedReview(quest);
 
     if (isParticipant && !hasSubmittedReview) {
       return {
@@ -258,199 +270,252 @@ const QuestList: React.FC = () => {
         className:
           "bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700",
       };
-    } else {
-      return {
-        text: "レビューを見る",
-        action: () => router.push(`/quests/${quest.id}`),
-        icon: Eye,
-        className:
-          "bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700",
-      };
     }
+
+    return {
+      text: "レビューを見る",
+      action: () => router.push(`/quests/${quest.id}`),
+      icon: Eye,
+      className:
+        "bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700",
+    };
   };
 
-  const handleJoinQuest = (quest: Quest) => {
-    setSelectedQuest(quest);
-    setIsDialogOpen(true);
-  };
+	const handleJoinQuest = (quest: Quest) => {
+		setSelectedQuest(quest);
+		setIsDialogOpen(true);
+	};
 
-  const normalizedSearchQuery = debouncedSearchQuery.toLowerCase();
-  const filterParams = {
-    selectedFilter,
-    normalizedSearchQuery,
-    startDateFilter,
-    endDateFilter,
-    hiddenStatuses: HIDDEN_QUEST_STATUSES,
-  };
-  const filteredQuests = filterQuests(quests, filterParams);
-  const suggestedQuests = getSuggestedQuests(quests, filterParams);
+	const commitSearchHistory = (query: string) => {
+		const nextHistory = persistQuestSearchHistory(query);
+		setSearchHistory(nextHistory);
+	};
 
-  if (loading) {
-    return <QuestListSkeleton />;
-  }
+	const normalizedSearchQuery = debouncedSearchQuery.toLowerCase();
+	const filterParams = {
+		selectedFilter,
+		normalizedSearchQuery,
+		startDateFilter,
+		endDateFilter,
+		hiddenStatuses: HIDDEN_QUEST_STATUSES,
+	};
+	const filteredQuests = filterQuests(quests, filterParams);
+	const suggestedQuests = getSuggestedQuests(quests, filterParams);
 
-  return (
-    <div className="w-full">
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
-        {/* Search and Filter */}
-        <div className="mb-8 space-y-4">
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-4 sm:flex-row">
-              <div
-                ref={searchContainerRef}
-                className="relative flex-1"
-                onBlur={(event) => {
-                  const nextTarget = event.relatedTarget as Node | null;
-                  if (nextTarget && searchContainerRef.current?.contains(nextTarget)) {
-                    return;
-                  }
+	if (loading) {
+		return <QuestListSkeleton />;
+	}
 
-                  setShowSuggestions(false);
-                }}
-              >
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-                <input
-                  type="text"
-                  placeholder="クエストを検索..."
-                  value={searchQuery}
-                  onFocus={() => setShowSuggestions(true)}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
-                />
+	return (
+		<div className="w-full">
+			<main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
+				{/* Search and Filter */}
+				<div className="mb-8 space-y-4">
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-4 sm:flex-row">
+							<div
+								ref={searchContainerRef}
+								className="relative flex-1"
+								onBlur={(event) => {
+									const nextTarget = event.relatedTarget as Node | null;
+									if (
+										nextTarget &&
+										searchContainerRef.current?.contains(nextTarget)
+									) {
+										return;
+									}
 
-                {showSuggestions && normalizedSearchQuery.length > 0 && (
-                  <div className="absolute z-20 mt-2 w-full overflow-hidden rounded-xl border border-slate-600 bg-slate-800 shadow-xl">
-                    {suggestedQuests.length > 0 ? (
-                      <ul className="divide-y divide-slate-700">
-                        {suggestedQuests.map((quest) => (
-                          <li key={quest.id}>
-                            <button
-                              type="button"
-                              className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition hover:bg-slate-700/80"
-                              onMouseDown={(event) => event.preventDefault()}
-                              onClick={() => {
-                                setSearchQuery(quest.title);
-                                setDebouncedSearchQuery(quest.title);
-                                setShowSuggestions(false);
-                              }}
-                            >
-                              <div>
-                                <p className="font-medium text-white">{quest.title}</p>
-                                <p className="mt-1 text-xs text-slate-300">
-                                  開始日: {formatDate(quest.start_date)}
-                                </p>
-                              </div>
-                              <span className="rounded-full bg-slate-700 px-2 py-1 text-xs text-slate-200">
-                                {quest.type}
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <div className="px-4 py-3 text-sm text-slate-300">
-                        タイトル一致する候補はありません
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
+									commitSearchHistory(searchQuery);
+									setShowSuggestions(false);
+								}}
+							>
+								<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+								<input
+									type="text"
+									placeholder="クエストを検索..."
+									value={searchQuery}
+									onFocus={() => setShowSuggestions(true)}
+									onChange={(e) => setSearchQuery(e.target.value)}
+									onKeyDown={(event) => {
+										if (event.key === "Enter") {
+											commitSearchHistory(searchQuery);
+										}
+									}}
+									className="w-full pl-10 pr-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
+								/>
 
-              <select
-                value={selectedFilter}
-                onChange={(e) => setSelectedFilter(e.target.value)}
-                className="px-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
-              >
-                <option value="all">全てのクエスト</option>
-                <option value="active">募集中</option>
-                <option value="in_progress">進行中</option>
-                <option value="inactive">停止中</option>
-                <option value="completed">完了済み</option>
-              </select>
-            </div>
+								{showSuggestions && (
+									<div className="absolute z-20 mt-2 w-full overflow-hidden rounded-xl border border-slate-600 bg-slate-800 shadow-xl">
+										{normalizedSearchQuery.length === 0 ? (
+											searchHistory.length > 0 ? (
+												<div>
+													<div className="border-b border-slate-700 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
+														検索履歴
+													</div>
+													<ul className="divide-y divide-slate-700">
+														{searchHistory.map((historyItem) => (
+															<li key={historyItem}>
+																<button
+																	type="button"
+																	className="flex w-full items-center gap-3 px-4 py-3 text-left transition hover:bg-slate-700/80"
+																	onMouseDown={(event) =>
+																		event.preventDefault()
+																	}
+																	onClick={() => {
+																		setSearchQuery(historyItem);
+																		setDebouncedSearchQuery(historyItem);
+																		commitSearchHistory(historyItem);
+																		setShowSuggestions(false);
+																	}}
+																>
+																	<Search className="h-4 w-4 text-slate-400" />
+																	<span className="text-sm text-white">
+																		{historyItem}
+																	</span>
+																</button>
+															</li>
+														))}
+													</ul>
+												</div>
+											) : (
+												<div className="px-4 py-3 text-sm text-slate-300">
+													検索履歴はまだありません
+												</div>
+											)
+										) : suggestedQuests.length > 0 ? (
+											<ul className="divide-y divide-slate-700">
+												{suggestedQuests.map((quest) => (
+													<li key={quest.id}>
+														<button
+															type="button"
+															className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition hover:bg-slate-700/80"
+															onMouseDown={(event) => event.preventDefault()}
+															onClick={() => {
+																setSearchQuery(quest.title);
+																setDebouncedSearchQuery(quest.title);
+																commitSearchHistory(quest.title);
+																setShowSuggestions(false);
+															}}
+														>
+															<div>
+																<p className="font-medium text-white">
+																	{quest.title}
+																</p>
+																<p className="mt-1 text-xs text-slate-300">
+																	開始日: {formatDate(quest.start_date)}
+																</p>
+															</div>
+															<span className="rounded-full bg-slate-700 px-2 py-1 text-xs text-slate-200">
+																{quest.type}
+															</span>
+														</button>
+													</li>
+												))}
+											</ul>
+										) : (
+											<div className="px-4 py-3 text-sm text-slate-300">
+												タイトル一致する候補はありません
+											</div>
+										)}
+									</div>
+								)}
+							</div>
 
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <label className="space-y-2">
-                <span className="text-sm font-medium text-slate-200">
-                  公開開始日 From
-                </span>
-                <input
-                  type="date"
-                  value={startDateFilter}
-                  onChange={(e) => setStartDateFilter(e.target.value)}
-                  className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
-                />
-              </label>
+							<select
+								value={selectedFilter}
+								onChange={(e) => setSelectedFilter(e.target.value)}
+								className="px-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
+							>
+								<option value="all">全てのクエスト</option>
+								<option value="active">募集中</option>
+								<option value="in_progress">進行中</option>
+								<option value="inactive">停止中</option>
+								<option value="completed">完了済み</option>
+							</select>
+						</div>
 
-              <label className="space-y-2">
-                <span className="text-sm font-medium text-slate-200">
-                  公開開始日 To
-                </span>
-                <input
-                  type="date"
-                  value={endDateFilter}
-                  min={startDateFilter || undefined}
-                  onChange={(e) => setEndDateFilter(e.target.value)}
-                  className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
-                />
-              </label>
+						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+							<label className="space-y-2">
+								<span className="text-sm font-medium text-slate-200">
+									公開開始日 From
+								</span>
+								<input
+									type="date"
+									value={startDateFilter}
+									onChange={(e) => setStartDateFilter(e.target.value)}
+									className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
+								/>
+							</label>
 
-              <div className="flex items-end sm:col-span-2 xl:justify-end">
-                <button
-                  type="button"
-                  className="w-full rounded-lg border border-slate-500 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-yellow-400 hover:text-yellow-300 xl:w-auto"
-                  onClick={() => {
-                    setSearchQuery("");
-                    setDebouncedSearchQuery("");
-                    setSelectedFilter("all");
-                    setStartDateFilter("");
-                    setEndDateFilter("");
-                    setShowSuggestions(false);
-                  }}
-                >
-                  フィルタをリセット
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+							<label className="space-y-2">
+								<span className="text-sm font-medium text-slate-200">
+									公開開始日 To
+								</span>
+								<input
+									type="date"
+									value={endDateFilter}
+									min={startDateFilter || undefined}
+									onChange={(e) => setEndDateFilter(e.target.value)}
+									className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
+								/>
+							</label>
 
-        {/* Quest Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-          {filteredQuests.map((quest) => (
-            <QuestListCard
-              key={quest.id}
-              quest={quest}
-              difficultyColor={getDifficultyColor(quest.difficulty)}
-              icon={getIconComponent(quest.type)}
-              formatCurrency={formatCurrency}
-              formatDate={formatDate}
-              onJoin={handleJoinQuest}
-              completedButtonAction={buttonActions.get(quest.id)}
-            />
-          ))}
-        </div>
+							<div className="flex items-end sm:col-span-2 xl:justify-end">
+								<button
+									type="button"
+									className="w-full rounded-lg border border-slate-500 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-yellow-400 hover:text-yellow-300 xl:w-auto"
+									onClick={() => {
+										setSearchQuery("");
+										setDebouncedSearchQuery("");
+										setSelectedFilter("all");
+										setStartDateFilter("");
+										setEndDateFilter("");
+										setShowSuggestions(false);
+									}}
+								>
+									フィルタをリセット
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
 
-        {filteredQuests.length === 0 && (
-          <div className="text-center py-12">
-            <div className="w-24 h-24 bg-slate-700 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Search className="w-12 h-12 text-gray-400" />
-            </div>
-            <h3 className="text-xl font-semibold text-gray-300 mb-2">
-              クエストが見つかりません
-            </h3>
-            <p className="text-gray-400">検索条件を変更してお試しください</p>
-          </div>
-        )}
+				{/* Quest Grid */}
+				<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
+					{filteredQuests.map((quest) => (
+						<QuestListCard
+							key={quest.id}
+							quest={quest}
+							difficultyColor={getDifficultyColor(quest.difficulty)}
+							icon={getIconComponent(quest.type)}
+							formatCurrency={formatCurrency}
+							formatDate={formatDate}
+							onJoin={handleJoinQuest}
+							completedButtonAction={buttonActions.get(quest.id)}
+						/>
+					))}
+				</div>
 
-        <QuestJoinDialog
-          quest={selectedQuest}
-          isOpen={isDialogOpen}
-          onClose={() => setIsDialogOpen(false)}
-        />
-      </main>
-    </div>
-  );
+				{filteredQuests.length === 0 && (
+					<div className="text-center py-12">
+						<div className="w-24 h-24 bg-slate-700 rounded-full flex items-center justify-center mx-auto mb-4">
+							<Search className="w-12 h-12 text-gray-400" />
+						</div>
+						<h3 className="text-xl font-semibold text-gray-300 mb-2">
+							クエストが見つかりません
+						</h3>
+						<p className="text-gray-400">検索条件を変更してお試しください</p>
+					</div>
+				)}
+
+				<QuestJoinDialog
+					quest={selectedQuest}
+					isOpen={isDialogOpen}
+					onClose={() => setIsDialogOpen(false)}
+				/>
+			</main>
+		</div>
+	);
 };
 
 export default QuestList;

--- a/apps/frontend/src/components/organisms/questSearchHistory.ts
+++ b/apps/frontend/src/components/organisms/questSearchHistory.ts
@@ -1,0 +1,59 @@
+const QUEST_SEARCH_HISTORY_KEY = "quest-list:search-history";
+const QUEST_SEARCH_HISTORY_LIMIT = 5;
+
+const normalizeHistoryEntry = (value: string) => value.trim();
+
+export const readQuestSearchHistory = () => {
+	if (typeof window === "undefined") {
+		return [];
+	}
+
+	try {
+		const rawValue = window.localStorage.getItem(QUEST_SEARCH_HISTORY_KEY);
+		if (!rawValue) {
+			return [];
+		}
+
+		const parsed = JSON.parse(rawValue);
+		if (!Array.isArray(parsed)) {
+			return [];
+		}
+
+		return parsed
+			.map((entry) =>
+				typeof entry === "string" ? normalizeHistoryEntry(entry) : "",
+			)
+			.filter((entry) => entry.length > 0)
+			.slice(0, QUEST_SEARCH_HISTORY_LIMIT);
+	} catch {
+		return [];
+	}
+};
+
+export const buildQuestSearchHistory = (history: string[], query: string) => {
+	const normalizedQuery = normalizeHistoryEntry(query);
+	if (!normalizedQuery) {
+		return history;
+	}
+
+	return [
+		normalizedQuery,
+		...history.filter((entry) => entry !== normalizedQuery),
+	].slice(0, QUEST_SEARCH_HISTORY_LIMIT);
+};
+
+export const persistQuestSearchHistory = (query: string) => {
+	if (typeof window === "undefined") {
+		return [];
+	}
+
+	const nextHistory = buildQuestSearchHistory(readQuestSearchHistory(), query);
+	window.localStorage.setItem(
+		QUEST_SEARCH_HISTORY_KEY,
+		JSON.stringify(nextHistory),
+	);
+
+	return nextHistory;
+};
+
+export { QUEST_SEARCH_HISTORY_KEY, QUEST_SEARCH_HISTORY_LIMIT };

--- a/apps/frontend/src/components/organisms/questSearchHistory.ts
+++ b/apps/frontend/src/components/organisms/questSearchHistory.ts
@@ -48,10 +48,15 @@ export const persistQuestSearchHistory = (query: string) => {
 	}
 
 	const nextHistory = buildQuestSearchHistory(readQuestSearchHistory(), query);
-	window.localStorage.setItem(
-		QUEST_SEARCH_HISTORY_KEY,
-		JSON.stringify(nextHistory),
-	);
+
+	try {
+		window.localStorage.setItem(
+			QUEST_SEARCH_HISTORY_KEY,
+			JSON.stringify(nextHistory),
+		);
+	} catch {
+		// プライベートモードや容量超過で setItem が失敗しても検索機能は継続する。
+	}
 
 	return nextHistory;
 };


### PR DESCRIPTION
## Summary
- issue #207 として Quest 一覧の検索欄に localStorage ベースの検索履歴を追加
- 検索欄フォーカス時に直近5件の履歴を表示し、選択すると即座に再検索できるように変更
- 履歴保存 helper と QuestList の挙動テストを追加

## Verification
- pnpm --filter frontend test
- pnpm --filter frontend build

## Notes
- pre-commit hook は Biome 通過後、vitest 起動時に optional dependency の @rollup/rollup-darwin-x64 解決で失敗しました
- hook 失敗とは別に、上記コマンドを手動実行してテストと build が通ることを確認しています
- closes #207
