### PR TITLE
feat: review系 API に認証保護を追加する (#54)

### DIFF
--- a/apps/backend/src/__tests__/controllers/reviewController.test.ts
+++ b/apps/backend/src/__tests__/controllers/reviewController.test.ts
@@ -1,0 +1,157 @@
+import type { NextFunction, Request, Response } from "express";
+import { ROLES } from "../../constants/roles";
+import {
+	createReview,
+	deleteReview,
+	updateReview,
+} from "../../controllers/reviewController";
+import {
+	createReviewService,
+	deleteReviewService,
+	getReviewByIdService,
+	updateReviewService,
+} from "../../services/reviewService";
+import { getUserByFirebaseUidService } from "../../services/userService";
+import { AppError } from "../../utils/appError";
+import { validateRequest } from "../../utils/validate";
+
+jest.mock("../../utils/validate", () => ({
+	validateRequest: jest.fn(),
+}));
+
+jest.mock("../../services/reviewService", () => ({
+	createReviewService: jest.fn(),
+	updateReviewService: jest.fn(),
+	deleteReviewService: jest.fn(),
+	getReviewByIdService: jest.fn(),
+}));
+
+jest.mock("../../services/userService", () => ({
+	getUserByFirebaseUidService: jest.fn(),
+}));
+
+const mockValidateRequest = validateRequest as jest.MockedFunction<
+	typeof validateRequest
+>;
+const mockCreateReviewService = createReviewService as jest.MockedFunction<
+	typeof createReviewService
+>;
+const mockUpdateReviewService = updateReviewService as jest.MockedFunction<
+	typeof updateReviewService
+>;
+const mockDeleteReviewService = deleteReviewService as jest.MockedFunction<
+	typeof deleteReviewService
+>;
+const mockGetReviewByIdService = getReviewByIdService as jest.MockedFunction<
+	typeof getReviewByIdService
+>;
+const mockGetUserByFirebaseUidService =
+	getUserByFirebaseUidService as jest.MockedFunction<
+		typeof getUserByFirebaseUidService
+	>;
+
+const createResponse = () =>
+	({
+		status: jest.fn().mockReturnThis(),
+		json: jest.fn(),
+		send: jest.fn(),
+	}) as unknown as Response;
+
+const waitForAsyncHandler = () =>
+	new Promise<void>((resolve) => {
+		setImmediate(() => resolve());
+	});
+
+describe("reviewController", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("createReview は body の reviewer_id を無視し、認証ユーザーの ID で作成する", async () => {
+		mockValidateRequest.mockReturnValue({
+			params: { questId: 1 },
+			body: { reviewer_id: 999, rating: 5, comment: "test" },
+			query: {},
+		} as never);
+		mockGetUserByFirebaseUidService.mockResolvedValueOnce({
+			id: 10,
+			role: ROLES.USER,
+		} as never);
+		mockCreateReviewService.mockResolvedValueOnce({ id: 1 } as never);
+
+		const req = { user: { uid: "firebase-uid-10" } } as Request;
+		const res = createResponse();
+		const next = jest.fn();
+
+		createReview(req, res, next as unknown as NextFunction);
+		await waitForAsyncHandler();
+
+		expect(mockCreateReviewService).toHaveBeenCalledWith({
+			questId: 1,
+			reviewer_id: 10,
+			rating: 5,
+			comment: "test",
+		});
+		expect(res.status).toHaveBeenCalledWith(201);
+		expect(next).not.toHaveBeenCalled();
+	});
+
+	it("updateReview はレビュー所有者以外の更新を 403 で拒否する", async () => {
+		mockValidateRequest.mockReturnValue({
+			params: { reviewId: 1 },
+			body: { rating: 3, comment: "updated" },
+			query: {},
+		} as never);
+		mockGetUserByFirebaseUidService.mockResolvedValueOnce({
+			id: 2,
+			role: ROLES.USER,
+		} as never);
+		mockGetReviewByIdService.mockResolvedValueOnce({
+			id: 1,
+			reviewer_id: 3,
+		} as never);
+
+		const req = { user: { uid: "firebase-uid-2" } } as Request;
+		const res = createResponse();
+		const next = jest.fn();
+
+		updateReview(req, res, next as unknown as NextFunction);
+		await waitForAsyncHandler();
+
+		expect(mockUpdateReviewService).not.toHaveBeenCalled();
+		expect(next).toHaveBeenCalled();
+		const error = next.mock.calls[0][0] as AppError;
+		expect(error).toBeInstanceOf(AppError);
+		expect(error.statusCode).toBe(403);
+		expect(error.code).toBe("FORBIDDEN");
+	});
+
+	it("deleteReview は admin なら他人のレビューも削除できる", async () => {
+		mockValidateRequest.mockReturnValue({
+			params: { reviewId: 5 },
+			body: {},
+			query: {},
+		} as never);
+		mockGetUserByFirebaseUidService.mockResolvedValueOnce({
+			id: 8,
+			role: ROLES.ADMIN,
+		} as never);
+		mockGetReviewByIdService.mockResolvedValueOnce({
+			id: 5,
+			reviewer_id: 99,
+		} as never);
+		mockDeleteReviewService.mockResolvedValueOnce(undefined as never);
+
+		const req = { user: { uid: "firebase-uid-8" } } as Request;
+		const res = createResponse();
+		const next = jest.fn();
+
+		deleteReview(req, res, next as unknown as NextFunction);
+		await waitForAsyncHandler();
+
+		expect(mockDeleteReviewService).toHaveBeenCalledWith(5);
+		expect(res.status).toHaveBeenCalledWith(204);
+		expect(res.send).toHaveBeenCalled();
+		expect(next).not.toHaveBeenCalled();
+	});
+});

--- a/apps/backend/src/__tests__/middlewares/auth.middleware.test.ts
+++ b/apps/backend/src/__tests__/middlewares/auth.middleware.test.ts
@@ -1,0 +1,153 @@
+import type { User } from "@prisma/client";
+import type { NextFunction, Request, Response } from "express";
+import { ROLES } from "../../constants/roles";
+import {
+	authMiddleware,
+	optionalAuthMiddleware,
+	requireAdmin,
+} from "../../middlewares/auth.middleware";
+import { getUserByFirebaseUidService } from "../../services/userService";
+import { AppError } from "../../utils/appError";
+
+const mockVerifyIdToken = jest.fn();
+
+jest.mock("../../config/firebase", () => ({
+	__esModule: true,
+	default: {
+		auth: () => ({
+			verifyIdToken: mockVerifyIdToken,
+		}),
+	},
+}));
+
+jest.mock("../../services/userService", () => ({
+	getUserByFirebaseUidService: jest.fn(),
+}));
+
+const mockedGetUserByFirebaseUidService =
+	getUserByFirebaseUidService as jest.MockedFunction<
+		typeof getUserByFirebaseUidService
+	>;
+
+const createRequest = (authorization?: string) =>
+	({
+		headers: authorization ? { authorization } : {},
+	}) as Request;
+
+const getNextError = (next: jest.Mock): AppError =>
+	next.mock.calls[0]?.[0] as AppError;
+
+describe("auth.middleware", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	describe("authMiddleware", () => {
+		it("Bearer トークンがない場合は 401 を返す", async () => {
+			const req = createRequest();
+			const next = jest.fn() as NextFunction;
+
+			await authMiddleware(req, {} as Response, next);
+
+			const error = getNextError(next as unknown as jest.Mock);
+			expect(error).toBeInstanceOf(AppError);
+			expect(error.statusCode).toBe(401);
+			expect(error.code).toBe("UNAUTHORIZED");
+		});
+
+		it("無効トークンの場合は 403 を返す", async () => {
+			const req = createRequest("Bearer invalid-token");
+			const next = jest.fn() as NextFunction;
+			mockVerifyIdToken.mockRejectedValueOnce(new Error("invalid token"));
+
+			await authMiddleware(req, {} as Response, next);
+
+			const error = getNextError(next as unknown as jest.Mock);
+			expect(error).toBeInstanceOf(AppError);
+			expect(error.statusCode).toBe(403);
+			expect(error.code).toBe("FORBIDDEN");
+		});
+
+		it("有効トークンの場合は req.user を設定して次へ進む", async () => {
+			const req = createRequest("Bearer valid-token");
+			const next = jest.fn() as NextFunction;
+			const decodedToken = { uid: "firebase-uid-1" };
+			mockVerifyIdToken.mockResolvedValueOnce(decodedToken);
+
+			await authMiddleware(req, {} as Response, next);
+
+			expect(req.user).toEqual(decodedToken);
+			expect(next).toHaveBeenCalledWith();
+		});
+	});
+
+	describe("optionalAuthMiddleware", () => {
+		it("Authorization ヘッダーなしでは匿名のまま通過する", async () => {
+			const req = createRequest();
+			const next = jest.fn() as NextFunction;
+
+			await optionalAuthMiddleware(req, {} as Response, next);
+
+			expect(req.user).toBeUndefined();
+			expect(next).toHaveBeenCalledWith();
+		});
+
+		it("無効トークンの場合は 403 を返す", async () => {
+			const req = createRequest("Bearer invalid-token");
+			const next = jest.fn() as NextFunction;
+			mockVerifyIdToken.mockRejectedValueOnce(new Error("invalid token"));
+
+			await optionalAuthMiddleware(req, {} as Response, next);
+
+			const error = getNextError(next as unknown as jest.Mock);
+			expect(error).toBeInstanceOf(AppError);
+			expect(error.statusCode).toBe(403);
+			expect(error.code).toBe("FORBIDDEN");
+		});
+	});
+
+	describe("requireAdmin", () => {
+		it("認証済みユーザー情報が無い場合は 401 を返す", async () => {
+			const req = createRequest();
+			const next = jest.fn() as NextFunction;
+
+			await requireAdmin(req, {} as Response, next);
+
+			const error = getNextError(next as unknown as jest.Mock);
+			expect(error).toBeInstanceOf(AppError);
+			expect(error.statusCode).toBe(401);
+			expect(error.code).toBe("UNAUTHORIZED");
+		});
+
+		it("アプリユーザー未登録の場合は 403 を返す", async () => {
+			const req = {
+				...createRequest(),
+				user: { uid: "missing-user" },
+			} as Request;
+			const next = jest.fn() as NextFunction;
+			mockedGetUserByFirebaseUidService.mockResolvedValueOnce(null);
+
+			await requireAdmin(req, {} as Response, next);
+
+			const error = getNextError(next as unknown as jest.Mock);
+			expect(error).toBeInstanceOf(AppError);
+			expect(error.statusCode).toBe(403);
+			expect(error.code).toBe("FORBIDDEN");
+		});
+
+		it("管理者ユーザーの場合は通過し req.appUser に格納される", async () => {
+			const req = {
+				...createRequest(),
+				user: { uid: "admin-user" },
+			} as Request;
+			const next = jest.fn() as NextFunction;
+			const adminUser = { id: 1, role: ROLES.ADMIN } as User;
+			mockedGetUserByFirebaseUidService.mockResolvedValueOnce(adminUser);
+
+			await requireAdmin(req, {} as Response, next);
+
+			expect(req.appUser).toEqual(adminUser);
+			expect(next).toHaveBeenCalledWith();
+		});
+	});
+});

--- a/apps/backend/src/__tests__/middlewares/auth.middleware.test.ts
+++ b/apps/backend/src/__tests__/middlewares/auth.middleware.test.ts
@@ -55,7 +55,7 @@ describe("auth.middleware", () => {
 			expect(error.code).toBe("UNAUTHORIZED");
 		});
 
-		it("無効トークンの場合は 403 を返す", async () => {
+		it("無効トークンの場合は 401 を返す", async () => {
 			const req = createRequest("Bearer invalid-token");
 			const next = jest.fn() as NextFunction;
 			mockVerifyIdToken.mockRejectedValueOnce(new Error("invalid token"));
@@ -64,8 +64,8 @@ describe("auth.middleware", () => {
 
 			const error = getNextError(next as unknown as jest.Mock);
 			expect(error).toBeInstanceOf(AppError);
-			expect(error.statusCode).toBe(403);
-			expect(error.code).toBe("FORBIDDEN");
+			expect(error.statusCode).toBe(401);
+			expect(error.code).toBe("UNAUTHORIZED");
 		});
 
 		it("有効トークンの場合は req.user を設定して次へ進む", async () => {
@@ -92,7 +92,7 @@ describe("auth.middleware", () => {
 			expect(next).toHaveBeenCalledWith();
 		});
 
-		it("無効トークンの場合は 403 を返す", async () => {
+		it("無効トークンの場合は 401 を返す", async () => {
 			const req = createRequest("Bearer invalid-token");
 			const next = jest.fn() as NextFunction;
 			mockVerifyIdToken.mockRejectedValueOnce(new Error("invalid token"));
@@ -101,8 +101,8 @@ describe("auth.middleware", () => {
 
 			const error = getNextError(next as unknown as jest.Mock);
 			expect(error).toBeInstanceOf(AppError);
-			expect(error.statusCode).toBe(403);
-			expect(error.code).toBe("FORBIDDEN");
+			expect(error.statusCode).toBe(401);
+			expect(error.code).toBe("UNAUTHORIZED");
 		});
 	});
 

--- a/apps/backend/src/__tests__/routes/authProtectionRoutes.test.ts
+++ b/apps/backend/src/__tests__/routes/authProtectionRoutes.test.ts
@@ -1,0 +1,63 @@
+process.env.DATABASE_URL =
+	process.env.DATABASE_URL ?? "mysql://user:password@localhost:3306/test_db";
+
+const questsRouter = require("../../routes/quests").default;
+const reviewsRouter = require("../../routes/reviews").default;
+const authMiddleware =
+	require("../../middlewares/auth.middleware").authMiddleware;
+
+type RouteMethod = "get" | "post" | "put" | "patch" | "delete";
+
+type RouteStackLayer = {
+	handle: unknown;
+	route?: {
+		path: string;
+		methods: Partial<Record<RouteMethod, boolean>>;
+		stack: RouteStackLayer[];
+	};
+};
+
+const getRouteHandlers = (
+	router: typeof questsRouter,
+	method: RouteMethod,
+	path: string,
+) => {
+	const routeLayer = (router as { stack: RouteStackLayer[] }).stack.find(
+		(layer) =>
+			layer.route && layer.route.path === path && layer.route.methods[method],
+	);
+
+	if (!routeLayer) {
+		throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
+	}
+
+	if (!routeLayer.route) {
+		throw new Error(`Route stack is missing: ${method.toUpperCase()} ${path}`);
+	}
+
+	return routeLayer.route.stack.map((layer) => layer.handle);
+};
+
+describe("認証保護ルート", () => {
+	it("POST /quests/:questId/reviews は authMiddleware を必須にする", () => {
+		const handlers = getRouteHandlers(
+			questsRouter,
+			"post",
+			"/:questId/reviews",
+		);
+
+		expect(handlers).toContain(authMiddleware);
+	});
+
+	it("PUT /reviews/:reviewId は authMiddleware を必須にする", () => {
+		const handlers = getRouteHandlers(reviewsRouter, "put", "/:reviewId");
+
+		expect(handlers).toContain(authMiddleware);
+	});
+
+	it("DELETE /reviews/:reviewId は authMiddleware を必須にする", () => {
+		const handlers = getRouteHandlers(reviewsRouter, "delete", "/:reviewId");
+
+		expect(handlers).toContain(authMiddleware);
+	});
+});

--- a/apps/backend/src/__tests__/routes/authProtectionRoutes.test.ts
+++ b/apps/backend/src/__tests__/routes/authProtectionRoutes.test.ts
@@ -1,63 +1,115 @@
 process.env.DATABASE_URL =
 	process.env.DATABASE_URL ?? "mysql://user:password@localhost:3306/test_db";
 
-const questsRouter = require("../../routes/quests").default;
-const reviewsRouter = require("../../routes/reviews").default;
-const authMiddleware =
-	require("../../middlewares/auth.middleware").authMiddleware;
+import { Readable, Writable } from "node:stream";
+import type { NextFunction } from "express";
+import express from "express";
+import { errorHandler } from "../../middlewares/errorHandler";
+import questsRouter from "../../routes/quests";
+import reviewsRouter from "../../routes/reviews";
 
-type RouteMethod = "get" | "post" | "put" | "patch" | "delete";
+const createApp = () => {
+	const app = express();
+	app.use(express.json());
+	app.use("/api/quests", questsRouter);
+	app.use("/api/reviews", reviewsRouter);
+	app.use(errorHandler);
+	return app;
+};
 
-type RouteStackLayer = {
-	handle: unknown;
-	route?: {
-		path: string;
-		methods: Partial<Record<RouteMethod, boolean>>;
-		stack: RouteStackLayer[];
+type MockResponse = Writable & {
+	statusCode: number;
+	setHeader: (name: string, value: string | string[] | number) => void;
+	getHeader: (name: string) => string | string[] | number | undefined;
+	removeHeader: (name: string) => void;
+	writeHead: (statusCode: number) => MockResponse;
+	end: (chunk?: string | Buffer) => MockResponse;
+};
+
+const request = async (path: string, method: "POST" | "PUT" | "DELETE") => {
+	const app = createApp() as ReturnType<typeof createApp> & {
+		handle: (req: Readable, res: Writable, next: NextFunction) => void;
+	};
+	const body = JSON.stringify({
+		rating: 5,
+		comment: "test",
+	});
+	const req = Object.assign(Readable.from([body]), {
+		method,
+		url: path,
+		headers: {
+			"content-type": "application/json",
+			"content-length": Buffer.byteLength(body).toString(),
+		},
+	});
+	const chunks: Buffer[] = [];
+	const headers = new Map<string, string | string[] | number>();
+	const res = Object.assign(
+		new Writable({
+			write(chunk, _encoding, callback) {
+				chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+				callback();
+			},
+		}),
+		{
+			statusCode: 200,
+			setHeader(name: string, value: string | string[] | number) {
+				headers.set(name.toLowerCase(), value);
+			},
+			getHeader(name: string) {
+				return headers.get(name.toLowerCase());
+			},
+			removeHeader(name: string) {
+				headers.delete(name.toLowerCase());
+			},
+			writeHead(statusCode: number) {
+				this.statusCode = statusCode;
+				return this;
+			},
+			end(chunk?: string | Buffer) {
+				if (chunk) {
+					chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+				}
+				(this as unknown as Writable).emit("finish");
+				return this;
+			},
+		},
+	) as unknown as MockResponse;
+
+	await new Promise<void>((resolve, reject) => {
+		res.on("finish", () => resolve());
+		res.on("error", reject);
+		app.handle(req, res, reject);
+	});
+
+	return {
+		status: res.statusCode,
+		json: () =>
+			JSON.parse(Buffer.concat(chunks).toString("utf8")) as {
+				code: string;
+			},
 	};
 };
 
-const getRouteHandlers = (
-	router: typeof questsRouter,
-	method: RouteMethod,
-	path: string,
-) => {
-	const routeLayer = (router as { stack: RouteStackLayer[] }).stack.find(
-		(layer) =>
-			layer.route && layer.route.path === path && layer.route.methods[method],
-	);
-
-	if (!routeLayer) {
-		throw new Error(`Route not found: ${method.toUpperCase()} ${path}`);
-	}
-
-	if (!routeLayer.route) {
-		throw new Error(`Route stack is missing: ${method.toUpperCase()} ${path}`);
-	}
-
-	return routeLayer.route.stack.map((layer) => layer.handle);
-};
-
 describe("認証保護ルート", () => {
-	it("POST /quests/:questId/reviews は authMiddleware を必須にする", () => {
-		const handlers = getRouteHandlers(
-			questsRouter,
-			"post",
-			"/:questId/reviews",
-		);
-
-		expect(handlers).toContain(authMiddleware);
+	it("POST /api/quests/:questId/reviews はトークン無しで 401 を返す", async () => {
+		const response = await request("/api/quests/1/reviews", "POST");
+		expect(response.status).toBe(401);
+		const body = (await response.json()) as { code: string };
+		expect(body.code).toBe("UNAUTHORIZED");
 	});
 
-	it("PUT /reviews/:reviewId は authMiddleware を必須にする", () => {
-		const handlers = getRouteHandlers(reviewsRouter, "put", "/:reviewId");
-
-		expect(handlers).toContain(authMiddleware);
+	it("PUT /api/reviews/:reviewId はトークン無しで 401 を返す", async () => {
+		const response = await request("/api/reviews/1", "PUT");
+		expect(response.status).toBe(401);
+		const body = (await response.json()) as { code: string };
+		expect(body.code).toBe("UNAUTHORIZED");
 	});
 
-	it("DELETE /reviews/:reviewId は authMiddleware を必須にする", () => {
-		const handlers = getRouteHandlers(reviewsRouter, "delete", "/:reviewId");
-
-		expect(handlers).toContain(authMiddleware);
+	it("DELETE /api/reviews/:reviewId はトークン無しで 401 を返す", async () => {
+		const response = await request("/api/reviews/1", "DELETE");
+		expect(response.status).toBe(401);
+		const body = (await response.json()) as { code: string };
+		expect(body.code).toBe("UNAUTHORIZED");
 	});
 });

--- a/apps/backend/src/controllers/reviewController.ts
+++ b/apps/backend/src/controllers/reviewController.ts
@@ -1,8 +1,9 @@
 import type { Request, Response } from "express";
+import { ROLES } from "../constants/roles";
 import {
 	QuestJoinParamSchema,
-	ReviewExistsQuerySchema,
 	ReviewCreateBodySchema,
+	ReviewExistsQuerySchema,
 	ReviewIdParamSchema,
 	ReviewUpdateBodySchema,
 	UserReviewParamSchema,
@@ -11,12 +12,34 @@ import {
 	checkUserReviewExistsService,
 	createReviewService,
 	deleteReviewService,
+	getReviewByIdService,
 	getReviewsByQuestIdService,
 	updateReviewService,
 } from "../services/reviewService";
-import { badRequest } from "../utils/appError";
+import { getUserByFirebaseUidService } from "../services/userService";
+import {
+	badRequest,
+	forbidden,
+	notFound,
+	unauthorized,
+} from "../utils/appError";
 import { asyncHandler } from "../utils/asyncHandler";
 import { validateRequest } from "../utils/validate";
+
+const resolveAuthenticatedUser = async (req: Request) => {
+	const firebaseUid = req.user?.uid;
+	if (!firebaseUid) {
+		throw unauthorized();
+	}
+
+	const user = req.appUser ?? (await getUserByFirebaseUidService(firebaseUid));
+	if (!user) {
+		throw forbidden("Forbidden: user not found");
+	}
+
+	req.appUser = user;
+	return user;
+};
 
 /**
  * クエストに紐づくレビュー一覧を返す。
@@ -39,13 +62,14 @@ export const createReview = asyncHandler(
 			params: QuestJoinParamSchema,
 			body: ReviewCreateBodySchema,
 		});
+		const currentUser = await resolveAuthenticatedUser(req);
 		const { questId } = params;
-		const { reviewer_id, rating, comment } = body;
+		const { rating, comment } = body;
 
 		try {
 			const review = await createReviewService({
 				questId,
-				reviewer_id,
+				reviewer_id: currentUser.id,
 				rating,
 				comment,
 			});
@@ -73,8 +97,19 @@ export const updateReview = asyncHandler(
 			params: ReviewIdParamSchema,
 			body: ReviewUpdateBodySchema,
 		});
+		const currentUser = await resolveAuthenticatedUser(req);
 		const { reviewId } = params;
 		const { rating, comment } = body;
+		const existingReview = await getReviewByIdService(reviewId);
+		if (!existingReview) {
+			throw notFound("Review not found");
+		}
+		if (
+			currentUser.role !== ROLES.ADMIN &&
+			existingReview.reviewer_id !== currentUser.id
+		) {
+			throw forbidden("Forbidden: review owner required");
+		}
 
 		const review = await updateReviewService(reviewId, {
 			rating,
@@ -90,7 +125,19 @@ export const updateReview = asyncHandler(
 export const deleteReview = asyncHandler(
 	async (req: Request, res: Response) => {
 		const { params } = validateRequest(req, { params: ReviewIdParamSchema });
+		const currentUser = await resolveAuthenticatedUser(req);
 		const { reviewId } = params;
+		const existingReview = await getReviewByIdService(reviewId);
+		if (!existingReview) {
+			throw notFound("Review not found");
+		}
+		if (
+			currentUser.role !== ROLES.ADMIN &&
+			existingReview.reviewer_id !== currentUser.id
+		) {
+			throw forbidden("Forbidden: review owner required");
+		}
+
 		await deleteReviewService(reviewId);
 		res.status(204).send();
 	},

--- a/apps/backend/src/dataAccessor/dbAccessor/Review.ts
+++ b/apps/backend/src/dataAccessor/dbAccessor/Review.ts
@@ -1,155 +1,169 @@
+import { type Review, User } from "@prisma/client";
 import { prisma } from "../../config/db";
-import { Review, User } from "@prisma/client";
 
 /**
  * ReviewWithRelations - レビューとその関連データを統合した拡張インターフェース
  */
 export interface ReviewWithRelations extends Review {
-  // レビュアー情報
-  reviewer: {
-    id: number;
-    name: string;
-  };
+	// レビュアー情報
+	reviewer: {
+		id: number;
+		name: string;
+	};
 }
 
 /**
  * レビュー作成用のデータインターフェース
  */
 export interface CreateReviewData {
-  questId: number;
-  reviewer_id: number;
-  rating: number;
-  comment?: string;
+	questId: number;
+	reviewer_id: number;
+	rating: number;
+	comment?: string;
 }
 
 /**
  * レビュー更新用のデータインターフェース
  */
 export interface UpdateReviewData {
-  rating: number;
-  comment?: string;
+	rating: number;
+	comment?: string;
 }
 
 /**
  * レビューテーブルと関連ユーザー情報へのアクセスを提供する。
  */
 export class ReviewDataAccessor {
-  /**
-   * クエストIDでレビュー一覧取得
-   *
-   * @param questId - クエストのID
-   * @returns レビュアー情報を含むレビュー一覧（作成日順で降順）
-   */
-  async findByQuestId(questId: number): Promise<ReviewWithRelations[]> {
-    const reviews = await prisma.review.findMany({
-      where: {
-        quest_id: questId,
-      } as any,
-      include: {
-        reviewer: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-      },
-      orderBy: {
-        created_at: "desc",
-      },
-    });
+	/**
+	 * レビューIDで1件取得
+	 *
+	 * @param reviewId - 取得するレビューのID
+	 * @returns レビュー情報。存在しない場合はnull
+	 */
+	async findById(reviewId: number): Promise<Review | null> {
+		return await prisma.review.findUnique({
+			where: {
+				id: reviewId,
+			},
+		});
+	}
 
-    return reviews as ReviewWithRelations[];
-  }
+	/**
+	 * クエストIDでレビュー一覧取得
+	 *
+	 * @param questId - クエストのID
+	 * @returns レビュアー情報を含むレビュー一覧（作成日順で降順）
+	 */
+	async findByQuestId(questId: number): Promise<ReviewWithRelations[]> {
+		const reviews = await prisma.review.findMany({
+			where: {
+				quest_id: questId,
+			},
+			include: {
+				reviewer: {
+					select: {
+						id: true,
+						name: true,
+					},
+				},
+			},
+			orderBy: {
+				created_at: "desc",
+			},
+		});
 
-  /**
-   * レビュー作成
-   *
-   * @param data - 作成するレビューのデータ
-   * @returns 作成されたレビュー情報（レビュアー情報含む）
-   */
-  async create(data: CreateReviewData): Promise<ReviewWithRelations> {
-    const review = await prisma.review.create({
-      data: {
-        reviewer_id: data.reviewer_id,
-        quest_id: data.questId,
-        rating: data.rating,
-        comment: data.comment,
-      } as any,
-      include: {
-        reviewer: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-      },
-    });
+		return reviews as ReviewWithRelations[];
+	}
 
-    return review as ReviewWithRelations;
-  }
+	/**
+	 * レビュー作成
+	 *
+	 * @param data - 作成するレビューのデータ
+	 * @returns 作成されたレビュー情報（レビュアー情報含む）
+	 */
+	async create(data: CreateReviewData): Promise<ReviewWithRelations> {
+		const review = await prisma.review.create({
+			data: {
+				reviewer_id: data.reviewer_id,
+				quest_id: data.questId,
+				rating: data.rating,
+				comment: data.comment,
+			},
+			include: {
+				reviewer: {
+					select: {
+						id: true,
+						name: true,
+					},
+				},
+			},
+		});
 
-  /**
-   * レビュー更新
-   *
-   * @param reviewId - 更新するレビューのID
-   * @param data - 更新データ
-   * @returns 更新後のレビュー情報（レビュアー情報含む）
-   */
-  async update(
-    reviewId: number,
-    data: UpdateReviewData
-  ): Promise<ReviewWithRelations> {
-    const review = await prisma.review.update({
-      where: {
-        id: reviewId,
-      },
-      data: {
-        rating: data.rating,
-        comment: data.comment,
-      },
-      include: {
-        reviewer: {
-          select: {
-            id: true,
-            name: true,
-          },
-        },
-      },
-    });
+		return review as ReviewWithRelations;
+	}
 
-    return review as ReviewWithRelations;
-  }
+	/**
+	 * レビュー更新
+	 *
+	 * @param reviewId - 更新するレビューのID
+	 * @param data - 更新データ
+	 * @returns 更新後のレビュー情報（レビュアー情報含む）
+	 */
+	async update(
+		reviewId: number,
+		data: UpdateReviewData,
+	): Promise<ReviewWithRelations> {
+		const review = await prisma.review.update({
+			where: {
+				id: reviewId,
+			},
+			data: {
+				rating: data.rating,
+				comment: data.comment,
+			},
+			include: {
+				reviewer: {
+					select: {
+						id: true,
+						name: true,
+					},
+				},
+			},
+		});
 
-  /**
-   * レビュー削除
-   *
-   * @param reviewId - 削除するレビューのID
-   * @returns 削除されたレビュー情報
-   */
-  async delete(reviewId: number): Promise<Review> {
-    return await prisma.review.delete({
-      where: {
-        id: reviewId,
-      },
-    });
-  }
+		return review as ReviewWithRelations;
+	}
 
-  /**
-   * ユーザーが特定のクエストにレビュー投稿済みかチェック
-   *
-   * @param userId - ユーザーのID
-   * @param questId - クエストのID
-   * @returns レビューが存在する場合はレビュー情報、存在しない場合はnull
-   */
-  async findByUserAndQuest(
-    userId: number,
-    questId: number
-  ): Promise<Review | null> {
-    return await prisma.review.findFirst({
-      where: {
-        reviewer_id: userId,
-        quest_id: questId,
-      } as any,
-    });
-  }
+	/**
+	 * レビュー削除
+	 *
+	 * @param reviewId - 削除するレビューのID
+	 * @returns 削除されたレビュー情報
+	 */
+	async delete(reviewId: number): Promise<Review> {
+		return await prisma.review.delete({
+			where: {
+				id: reviewId,
+			},
+		});
+	}
+
+	/**
+	 * ユーザーが特定のクエストにレビュー投稿済みかチェック
+	 *
+	 * @param userId - ユーザーのID
+	 * @param questId - クエストのID
+	 * @returns レビューが存在する場合はレビュー情報、存在しない場合はnull
+	 */
+	async findByUserAndQuest(
+		userId: number,
+		questId: number,
+	): Promise<Review | null> {
+		return await prisma.review.findFirst({
+			where: {
+				reviewer_id: userId,
+				quest_id: questId,
+			},
+		});
+	}
 }

--- a/apps/backend/src/middlewares/auth.middleware.ts
+++ b/apps/backend/src/middlewares/auth.middleware.ts
@@ -38,7 +38,7 @@ export const authMiddleware = async (
 		next();
 	} catch (error) {
 		logger.warn({ err: error }, "Firebase トークンの検証に失敗しました");
-		return next(forbidden("Forbidden: Invalid token"));
+		return next(unauthorized("Unauthorized: Invalid token"));
 	}
 };
 
@@ -69,7 +69,7 @@ export const optionalAuthMiddleware = async (
 		next();
 	} catch (error) {
 		logger.warn({ err: error }, "Firebase トークンの任意検証に失敗しました");
-		return next(forbidden("Forbidden: Invalid token"));
+		return next(unauthorized("Unauthorized: Invalid token"));
 	}
 };
 

--- a/apps/backend/src/middlewares/auth.middleware.ts
+++ b/apps/backend/src/middlewares/auth.middleware.ts
@@ -1,117 +1,117 @@
-import { Request, Response, NextFunction } from "express";
-import admin from "../config/firebase"; // 初期化済みの Firebase Admin SDK を利用
 import type { User } from "@prisma/client";
-import { ROLES } from "../constants/roles";
+import type { NextFunction, Request, Response } from "express";
+import admin from "../config/firebase"; // 初期化済みの Firebase Admin SDK を利用
 import { logger } from "../config/logger";
+import { ROLES } from "../constants/roles";
 import { getUserByFirebaseUidService } from "../services/userService";
-import { forbidden, unauthorized, AppError } from "../utils/appError";
+import { AppError, forbidden, unauthorized } from "../utils/appError";
 
 // Express リクエスト用の型拡張（userを付与するため）
 declare global {
-  namespace Express {
-    interface Request {
-      user?: admin.auth.DecodedIdToken;
-      appUser?: User;
-    }
-  }
+	namespace Express {
+		interface Request {
+			user?: admin.auth.DecodedIdToken;
+			appUser?: User;
+		}
+	}
 }
 
 /**
  * Bearer トークンを検証し、Firebase のデコード済みユーザー情報を `req.user` に格納する。
  */
 export const authMiddleware = async (
-  req: Request,
-  _res: Response,
-  next: NextFunction
+	req: Request,
+	_res: Response,
+	next: NextFunction,
 ) => {
-  const authHeader = req.headers.authorization;
+	const authHeader = req.headers.authorization;
 
-  if (!authHeader?.startsWith("Bearer ")) {
-    return next(unauthorized("Unauthorized: Bearer token missing"));
-  }
+	if (!authHeader?.startsWith("Bearer ")) {
+		return next(unauthorized("Unauthorized: Bearer token missing"));
+	}
 
-  const idToken = authHeader.split("Bearer ")[1];
+	const idToken = authHeader.split("Bearer ")[1];
 
-  try {
-    const decodedToken = await admin.auth().verifyIdToken(idToken);
-    req.user = decodedToken;
-    next();
-  } catch (error) {
-    logger.warn({ err: error }, "Firebase トークンの検証に失敗しました");
-    return next(unauthorized("Unauthorized: Invalid token"));
-  }
+	try {
+		const decodedToken = await admin.auth().verifyIdToken(idToken);
+		req.user = decodedToken;
+		next();
+	} catch (error) {
+		logger.warn({ err: error }, "Firebase トークンの検証に失敗しました");
+		return next(forbidden("Forbidden: Invalid token"));
+	}
 };
 
 /**
  * Bearer トークンがある場合のみ検証し、未指定時は匿名のまま通過する。
  */
 export const optionalAuthMiddleware = async (
-  req: Request,
-  _res: Response,
-  next: NextFunction
+	req: Request,
+	_res: Response,
+	next: NextFunction,
 ) => {
-  const authHeader = req.headers.authorization;
+	const authHeader = req.headers.authorization;
 
-  if (!authHeader) {
-    next();
-    return;
-  }
+	if (!authHeader) {
+		next();
+		return;
+	}
 
-  if (!authHeader.startsWith("Bearer ")) {
-    return next(unauthorized("Unauthorized: Invalid authorization header"));
-  }
+	if (!authHeader.startsWith("Bearer ")) {
+		return next(unauthorized("Unauthorized: Invalid authorization header"));
+	}
 
-  const idToken = authHeader.split("Bearer ")[1];
+	const idToken = authHeader.split("Bearer ")[1];
 
-  try {
-    const decodedToken = await admin.auth().verifyIdToken(idToken);
-    req.user = decodedToken;
-    next();
-  } catch (error) {
-    logger.warn({ err: error }, "Firebase トークンの任意検証に失敗しました");
-    return next(unauthorized("Unauthorized: Invalid token"));
-  }
+	try {
+		const decodedToken = await admin.auth().verifyIdToken(idToken);
+		req.user = decodedToken;
+		next();
+	} catch (error) {
+		logger.warn({ err: error }, "Firebase トークンの任意検証に失敗しました");
+		return next(forbidden("Forbidden: Invalid token"));
+	}
 };
 
 /**
  * 認証済みユーザーが管理者ロールを持つことを検証する。
  */
 export const requireAdmin = async (
-  req: Request,
-  _res: Response,
-  next: NextFunction
+	req: Request,
+	_res: Response,
+	next: NextFunction,
 ) => {
-  const firebaseUid = req.user?.uid;
+	const firebaseUid = req.user?.uid;
 
-  if (!firebaseUid) {
-    return next(unauthorized());
-  }
+	if (!firebaseUid) {
+		return next(unauthorized());
+	}
 
-  try {
-    const appUser =
-      req.appUser ?? (await getUserByFirebaseUidService(firebaseUid));
+	try {
+		const appUser =
+			req.appUser ?? (await getUserByFirebaseUidService(firebaseUid));
 
-    if (!appUser) {
-      return next(forbidden("Forbidden: user not found"));
-    }
+		if (!appUser) {
+			return next(forbidden("Forbidden: user not found"));
+		}
 
-    if (appUser.role !== ROLES.ADMIN) {
-      return next(forbidden("Forbidden: admin access required"));
-    }
+		if (appUser.role !== ROLES.ADMIN) {
+			return next(forbidden("Forbidden: admin access required"));
+		}
 
-    req.appUser = appUser;
-    next();
-    return;
-  } catch (error) {
-    logger.error({ err: error }, "管理者権限の検証に失敗しました");
-    return next(
-      error instanceof AppError
-        ? error
-        : new AppError(
-            "Failed to authorize admin user",
-            500,
-            "ADMIN_AUTHORIZATION_FAILED"
-          )
-      );
-  }
+		req.appUser = appUser;
+		next();
+		return;
+	} catch (error) {
+		logger.error({ err: error }, "管理者権限の検証に失敗しました");
+		return next(
+			error instanceof AppError
+				? error
+				: new AppError(
+						"Failed to authorize admin user",
+						500,
+						"ADMIN_AUTHORIZATION_FAILED",
+					),
+		);
+	}
 };

--- a/apps/backend/src/routes/quests.ts
+++ b/apps/backend/src/routes/quests.ts
@@ -1,25 +1,25 @@
 import express from "express";
 import {
-  getAllQuests,
-  getQuestById,
-  updateQuestStatus,
-  createQuest,
-  updateQuest,
-  deleteQuest,
-  reactivateQuest,
-  submitQuestForApproval,
-  restoreQuest,
+	createQuest,
+	deleteQuest,
+	getAllQuests,
+	getQuestById,
+	reactivateQuest,
+	restoreQuest,
+	submitQuestForApproval,
+	updateQuest,
+	updateQuestStatus,
 } from "../controllers/questController";
 import { joinQuest } from "../controllers/questJoinController";
 import {
-  authMiddleware,
-  optionalAuthMiddleware,
-  requireAdmin,
-} from "../middlewares/auth.middleware";
-import {
-  createReview,
-  getReviewsByQuestId,
+	createReview,
+	getReviewsByQuestId,
 } from "../controllers/reviewController";
+import {
+	authMiddleware,
+	optionalAuthMiddleware,
+	requireAdmin,
+} from "../middlewares/auth.middleware";
 
 const router = express.Router();
 
@@ -33,7 +33,7 @@ router.post("/:id/restorations", authMiddleware, requireAdmin, restoreQuest); //
 router.post("/:id/activations", authMiddleware, requireAdmin, reactivateQuest); // POST /quests/:id/activations
 router.delete("/:id", authMiddleware, requireAdmin, deleteQuest); // DELETE /quests/:id (論理削除)
 router.get("/:questId/reviews", getReviewsByQuestId); // GET /quests/:questId/reviews
-router.post("/:questId/reviews", createReview); // POST /quests/:questId/reviews
+router.post("/:questId/reviews", authMiddleware, createReview); // POST /quests/:questId/reviews
 router.post("/:questId/participants", authMiddleware, joinQuest); // POST /quests/:questId/participants
 
 export default router;

--- a/apps/backend/src/routes/reviews.ts
+++ b/apps/backend/src/routes/reviews.ts
@@ -1,12 +1,10 @@
 import express from "express";
-import {
-  updateReview,
-  deleteReview,
-} from "../controllers/reviewController";
+import { deleteReview, updateReview } from "../controllers/reviewController";
+import { authMiddleware } from "../middlewares/auth.middleware";
 
 const router = express.Router();
 
-router.put("/:reviewId", updateReview); // PUT /reviews/:reviewId
-router.delete("/:reviewId", deleteReview); // DELETE /reviews/:reviewId
+router.put("/:reviewId", authMiddleware, updateReview); // PUT /reviews/:reviewId
+router.delete("/:reviewId", authMiddleware, deleteReview); // DELETE /reviews/:reviewId
 
 export default router;

--- a/apps/backend/src/schemas/api.ts
+++ b/apps/backend/src/schemas/api.ts
@@ -228,7 +228,6 @@ export const ReviewSchema = z
 
 export const ReviewCreateBodySchema = z
 	.object({
-		reviewer_id: z.coerce.number().int().positive(),
 		rating: z.coerce.number().int().min(1).max(5),
 		comment: z.string().optional(),
 	})

--- a/apps/backend/src/services/reviewService.ts
+++ b/apps/backend/src/services/reviewService.ts
@@ -1,9 +1,9 @@
-import {
-  ReviewDataAccessor,
-  CreateReviewData,
-  UpdateReviewData,
-} from "../dataAccessor/dbAccessor";
 import { logger } from "../config/logger";
+import {
+	type CreateReviewData,
+	ReviewDataAccessor,
+	type UpdateReviewData,
+} from "../dataAccessor/dbAccessor";
 
 const reviewDataAccessor = new ReviewDataAccessor();
 
@@ -13,8 +13,18 @@ const reviewDataAccessor = new ReviewDataAccessor();
  * @returns レビュー一覧
  */
 export const getReviewsByQuestIdService = async (questId: number) => {
-  const reviews = await reviewDataAccessor.findByQuestId(questId);
-  return reviews;
+	const reviews = await reviewDataAccessor.findByQuestId(questId);
+	return reviews;
+};
+
+/**
+ * レビュー ID から 1 件取得する。
+ * @param reviewId - 対象レビューの ID
+ * @returns レビュー情報。見つからない場合は `null`
+ */
+export const getReviewByIdService = async (reviewId: number) => {
+	const review = await reviewDataAccessor.findById(reviewId);
+	return review;
 };
 
 /**
@@ -23,23 +33,23 @@ export const getReviewsByQuestIdService = async (questId: number) => {
  * @returns 作成後のレビュー情報
  */
 export const createReviewService = async (data: CreateReviewData) => {
-  try {
-    // 既存のレビューをチェック（1アカウント1投稿の制限）
-    const existingReview = await reviewDataAccessor.findByUserAndQuest(
-      data.reviewer_id,
-      data.questId
-    );
+	try {
+		// 既存のレビューをチェック（1アカウント1投稿の制限）
+		const existingReview = await reviewDataAccessor.findByUserAndQuest(
+			data.reviewer_id,
+			data.questId,
+		);
 
-    if (existingReview) {
-      throw new Error("このクエストには既にレビューを投稿済みです。");
-    }
+		if (existingReview) {
+			throw new Error("このクエストには既にレビューを投稿済みです。");
+		}
 
-    const review = await reviewDataAccessor.create(data);
-    return review;
-  } catch (error) {
-    logger.error({ err: error, reviewData: data }, "レビュー作成エラー");
-    throw error;
-  }
+		const review = await reviewDataAccessor.create(data);
+		return review;
+	} catch (error) {
+		logger.error({ err: error, reviewData: data }, "レビュー作成エラー");
+		throw error;
+	}
 };
 
 /**
@@ -49,11 +59,11 @@ export const createReviewService = async (data: CreateReviewData) => {
  * @returns 更新後のレビュー情報
  */
 export const updateReviewService = async (
-  reviewId: number,
-  data: UpdateReviewData
+	reviewId: number,
+	data: UpdateReviewData,
 ) => {
-  const review = await reviewDataAccessor.update(reviewId, data);
-  return review;
+	const review = await reviewDataAccessor.update(reviewId, data);
+	return review;
 };
 
 /**
@@ -62,7 +72,7 @@ export const updateReviewService = async (
  * @returns 削除完了後の Promise
  */
 export const deleteReviewService = async (reviewId: number) => {
-  await reviewDataAccessor.delete(reviewId);
+	await reviewDataAccessor.delete(reviewId);
 };
 
 /**
@@ -72,14 +82,14 @@ export const deleteReviewService = async (reviewId: number) => {
  * @returns 投稿済みなら `true`
  */
 export const checkUserReviewExistsService = async (
-  userId: number,
-  questId: number
+	userId: number,
+	questId: number,
 ) => {
-  try {
-    const review = await reviewDataAccessor.findByUserAndQuest(userId, questId);
-    return !!review;
-  } catch (error) {
-    logger.error({ err: error, userId, questId }, "レビュー存在チェックエラー");
-    throw error;
-  }
+	try {
+		const review = await reviewDataAccessor.findByUserAndQuest(userId, questId);
+		return !!review;
+	} catch (error) {
+		logger.error({ err: error, userId, questId }, "レビュー存在チェックエラー");
+		throw error;
+	}
 };

--- a/apps/frontend/src/components/pages/QuestDetailPage.tsx
+++ b/apps/frontend/src/components/pages/QuestDetailPage.tsx
@@ -186,7 +186,6 @@ const QuestDetailPage: React.FC<QuestDetailPageProps> = ({
 
       // APIにレビューを投稿
       const response = await reviewService.createReview(questId, {
-        reviewer_id: currentUserId,
         rating: newReview.score,
         comment: newReview.comment,
       });

--- a/apps/frontend/src/services/review.ts
+++ b/apps/frontend/src/services/review.ts
@@ -1,4 +1,4 @@
-import { apiClient } from "./httpClient";
+import { apiClient, authenticatedApiClient } from "./httpClient";
 
 export interface ReviewResponse {
   id: number;
@@ -14,7 +14,6 @@ export interface ReviewResponse {
 }
 
 export interface CreateReviewRequest {
-  reviewer_id: number;
   rating: number;
   comment?: string;
 }
@@ -42,7 +41,7 @@ export const reviewService = {
     questId: string,
     data: CreateReviewRequest
   ): Promise<ReviewResponse> => {
-    return apiClient.post<ReviewResponse, CreateReviewRequest>(
+    return authenticatedApiClient.post<ReviewResponse, CreateReviewRequest>(
       `/quests/${questId}/reviews`,
       data
     );
@@ -55,7 +54,7 @@ export const reviewService = {
     reviewId: string,
     data: UpdateReviewRequest
   ): Promise<ReviewResponse> => {
-    return apiClient.put<ReviewResponse, UpdateReviewRequest>(
+    return authenticatedApiClient.put<ReviewResponse, UpdateReviewRequest>(
       `/reviews/${reviewId}`,
       data
     );
@@ -65,7 +64,7 @@ export const reviewService = {
    * レビューを削除
    */
   deleteReview: async (reviewId: string): Promise<void> => {
-    return apiClient.delete<void>(`/reviews/${reviewId}`);
+    return authenticatedApiClient.delete<void>(`/reviews/${reviewId}`);
   },
 
   /**


### PR DESCRIPTION
## Summary
- review 作成時の `reviewer_id` をリクエスト body から受け取らず、認証済みユーザーから解決するようにした
- review 更新/削除時に所有者または管理者のみ許可する認可チェックを追加した
- review controller の単体テストと、認証保護ルートの 401 応答テストを追加した

## Verification
- `pnpm --filter backend test -- --runTestsByPath src/__tests__/middlewares/auth.middleware.test.ts src/__tests__/routes/authProtectionRoutes.test.ts src/__tests__/controllers/reviewController.test.ts`
- `pnpm --filter backend typecheck`

## Notes
- invalid token ケースの warn ログは想定どおりです
- review 作成/更新/削除は 401 と 403 を用途に応じて返し分けます
- related issue: #54
