### PR TITLE
refactor: frontend と E2E の重複設定を整理する (#161)

### DIFF
--- a/apps/e2e/tests/quest-entry-offer.ui.spec.ts
+++ b/apps/e2e/tests/quest-entry-offer.ui.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect, Page } from "@playwright/test";
+import { randomUUID } from "node:crypto";
+import { type Locator, type Page, expect, test } from "@playwright/test";
 import { PrismaClient } from "@prisma/client";
-import { randomUUID } from "crypto";
 
-const BASE_URL = "http://localhost:3000";
+const BASE_URL = process.env.FRONTEND_BASE_URL ?? "http://localhost:3000";
 
 // E2E 用の固定ユーザー情報
 const USER_EMAIL = "questboard+002@example.com";
@@ -16,451 +16,451 @@ const ADMIN_EMAIL = "questboard@example.com";
 const ADMIN_PASSWORD = "Abcd1234";
 
 async function login(page: Page, email: string, password: string) {
-  await page.goto(`${BASE_URL}/login`);
+	await page.goto(`${BASE_URL}/login`);
 
-  await page
-    .getByPlaceholder("メールアドレス")
-    .fill(email, { timeout: 10_000 });
-  await page.getByPlaceholder("パスワード").fill(password);
+	await page
+		.getByPlaceholder("メールアドレス")
+		.fill(email, { timeout: 10_000 });
+	await page.getByPlaceholder("パスワード").fill(password);
 
-  // ログイン成功アラートを待つ（クリック前に待機を設定）
-  const dialogPromise = page.waitForEvent("dialog", { timeout: 15_000 });
-  await page.getByRole("button", { name: "ログイン" }).click();
+	// ログイン成功アラートを待つ（クリック前に待機を設定）
+	const dialogPromise = page.waitForEvent("dialog", { timeout: 15_000 });
+	await page.getByRole("button", { name: "ログイン" }).click();
 
-  const dialog = await dialogPromise;
-  expect(dialog.message()).toContain("ログイン成功");
-  await dialog.accept();
+	const dialog = await dialogPromise;
+	expect(dialog.message()).toContain("ログイン成功");
+	await dialog.accept();
 
-  // ログイン後のリダイレクトを待つ（トップページにリダイレクトされる）
-  await page.waitForURL(`${BASE_URL}/`, { timeout: 10_000 });
-  await page.waitForLoadState("networkidle");
+	// ログイン後のリダイレクトを待つ（トップページにリダイレクトされる）
+	await page.waitForURL(`${BASE_URL}/`, { timeout: 10_000 });
+	await page.waitForLoadState("networkidle");
 }
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("クエストエントリー UI E2E", () => {
-  const prisma = new PrismaClient();
-  const cleanupIds = {
-    questIds: [] as number[],
-    rewardIds: [] as number[],
-  };
+	const prisma = new PrismaClient();
+	const cleanupIds = {
+		questIds: [] as number[],
+		rewardIds: [] as number[],
+	};
 
-  // テスト実行ごとのクエストIDを保存（クリーンアップ用）
-  const testQuestIds = new Map<string, number[]>();
+	// テスト実行ごとのクエストIDを保存（クリーンアップ用）
+	const testQuestIds = new Map<string, number[]>();
 
-  // 各テスト実行ごとに独立したクエストを作成（ブラウザ間の並列実行に対応）
-  test.beforeEach(async () => {
-    // テストユーザーの既存の参加記録をクリーンアップ（重複参加を防ぐため）
-    const testUser = await prisma.user.findUnique({
-      where: { email: USER_EMAIL },
-    });
-    if (testUser) {
-      // すべての参加記録を削除（テストの独立性を保つため）
-      await prisma.$transaction(async (tx) => {
-        await tx.questParticipant.deleteMany({
-          where: { user_id: testUser.id },
-        });
-      });
-      // クリーンアップ後に少し待機（データベースの更新を確実にするため）
-      await new Promise((resolve) => setTimeout(resolve, 500));
-    }
+	// 各テスト実行ごとに独立したクエストを作成（ブラウザ間の並列実行に対応）
+	test.beforeEach(async () => {
+		// テストユーザーの既存の参加記録をクリーンアップ（重複参加を防ぐため）
+		const testUser = await prisma.user.findUnique({
+			where: { email: USER_EMAIL },
+		});
+		if (testUser) {
+			// すべての参加記録を削除（テストの独立性を保つため）
+			await prisma.$transaction(async (tx) => {
+				await tx.questParticipant.deleteMany({
+					where: { user_id: testUser.id },
+				});
+			});
+			// クリーンアップ後に少し待機（データベースの更新を確実にするため）
+			await new Promise((resolve) => setTimeout(resolve, 500));
+		}
 
-    const uniqueId = randomUUID();
-    const baseDates = {
-      start: new Date(),
-      end: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
-    };
+		const uniqueId = randomUUID();
+		const baseDates = {
+			start: new Date(),
+			end: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+		};
 
-    // テスト用のクエストを作成（status: "active"で一般ユーザーに表示される）
-    const testQuest = await prisma.quest.create({
-      data: {
-        title: `E2Eテストクエスト-${uniqueId.slice(0, 8)}`,
-        description: "E2Eテストで使用するクエストです。",
-        type: "development",
-        status: "active", // "pending"は一般ユーザーに非表示のため"active"を使用
-        maxParticipants: 10,
-        start_date: baseDates.start,
-        end_date: baseDates.end,
-        tags: ["e2e", "test", uniqueId],
-        rewards: {
-          create: {
-            incentive_amount: 5000,
-            point_amount: 150,
-            note: "E2Eテスト用の報酬",
-          },
-        },
-      },
-      include: {
-        rewards: true,
-      },
-    });
-    cleanupIds.questIds.push(testQuest.id);
-    if (testQuest.rewards) {
-      cleanupIds.rewardIds.push(testQuest.rewards.id);
-    }
+		// テスト用のクエストを作成（status: "active"で一般ユーザーに表示される）
+		const testQuest = await prisma.quest.create({
+			data: {
+				title: `E2Eテストクエスト-${uniqueId.slice(0, 8)}`,
+				description: "E2Eテストで使用するクエストです。",
+				type: "development",
+				status: "active", // "pending"は一般ユーザーに非表示のため"active"を使用
+				maxParticipants: 10,
+				start_date: baseDates.start,
+				end_date: baseDates.end,
+				tags: ["e2e", "test", uniqueId],
+				rewards: {
+					create: {
+						incentive_amount: 5000,
+						point_amount: 150,
+						note: "E2Eテスト用の報酬",
+					},
+				},
+			},
+			include: {
+				rewards: true,
+			},
+		});
+		cleanupIds.questIds.push(testQuest.id);
+		if (testQuest.rewards) {
+			cleanupIds.rewardIds.push(testQuest.rewards.id);
+		}
 
-    // テストコンテキストにクエストIDを保存
-    test.info().annotations.push({
-      type: "quest-id",
-      description: String(testQuest.id),
-    });
-    test.info().annotations.push({
-      type: "quest-title",
-      description: testQuest.title,
-    });
-  });
+		// テストコンテキストにクエストIDを保存
+		test.info().annotations.push({
+			type: "quest-id",
+			description: String(testQuest.id),
+		});
+		test.info().annotations.push({
+			type: "quest-title",
+			description: testQuest.title,
+		});
+	});
 
-  test.afterAll(async () => {
-    // クエスト参加者を先に削除（外部キー制約のため）
-    await prisma.questParticipant.deleteMany({
-      where: {
-        quest_id: { in: cleanupIds.questIds },
-      },
-    });
+	test.afterAll(async () => {
+		// クエスト参加者を先に削除（外部キー制約のため）
+		await prisma.questParticipant.deleteMany({
+			where: {
+				quest_id: { in: cleanupIds.questIds },
+			},
+		});
 
-    // クエストを削除（関連するRewardも自動削除される）
-    await prisma.quest.deleteMany({
-      where: {
-        id: { in: cleanupIds.questIds },
-      },
-    });
-    await prisma.$disconnect();
-  });
+		// クエストを削除（関連するRewardも自動削除される）
+		await prisma.quest.deleteMany({
+			where: {
+				id: { in: cleanupIds.questIds },
+			},
+		});
+		await prisma.$disconnect();
+	});
 
-  test("一般ユーザーがクエストに応募できる", async ({ page }) => {
-    // テストで作成したクエストのタイトルを取得
-    const questTitleAnnotation = test
-      .info()
-      .annotations.find((a) => a.type === "quest-title");
-    const testQuestTitle = questTitleAnnotation
-      ? questTitleAnnotation.description
-      : null;
+	test("一般ユーザーがクエストに応募できる", async ({ page }) => {
+		// テストで作成したクエストのタイトルを取得
+		const questTitleAnnotation = test
+			.info()
+			.annotations.find((a) => a.type === "quest-title");
+		const testQuestTitle = questTitleAnnotation
+			? questTitleAnnotation.description
+			: null;
 
-    // ログイン
-    await login(page, USER_EMAIL, USER_PASSWORD);
+		// ログイン
+		await login(page, USER_EMAIL, USER_PASSWORD);
 
-    // クエスト一覧へ（リダイレクトを待つ）
-    await page.goto(`${BASE_URL}/quests`, { waitUntil: "networkidle" });
+		// クエスト一覧へ（リダイレクトを待つ）
+		await page.goto(`${BASE_URL}/quests`, { waitUntil: "networkidle" });
 
-    // 「クエストが見つかりません」メッセージが表示されていないことを確認
-    const noQuestMessage = page.getByText("クエストが見つかりません");
-    await expect(noQuestMessage)
-      .not.toBeVisible({ timeout: 5000 })
-      .catch(() => {
-        // メッセージが表示されていても、クエストが後で表示される可能性があるので続行
-      });
+		// 「クエストが見つかりません」メッセージが表示されていないことを確認
+		const noQuestMessage = page.getByText("クエストが見つかりません");
+		await expect(noQuestMessage)
+			.not.toBeVisible({ timeout: 5000 })
+			.catch(() => {
+				// メッセージが表示されていても、クエストが後で表示される可能性があるので続行
+			});
 
-    // 「クエストに参加する」ボタンが表示されるまで待機
-    await page.waitForSelector('button:has-text("クエストに参加する")', {
-      timeout: 15000,
-    });
+		// 「クエストに参加する」ボタンが表示されるまで待機
+		await page.waitForSelector('button:has-text("クエストに参加する")', {
+			timeout: 15000,
+		});
 
-    // テストで作成したクエストのカードを探す
-    let questCard;
-    let firstJoinButton;
+		// テストで作成したクエストのカードを探す
+		let questCard: Locator | undefined;
+		let firstJoinButton: Locator | undefined;
 
-    if (testQuestTitle) {
-      // テストで作成したクエストが表示されるまで待機
-      try {
-        await page.waitForSelector(`text=${testQuestTitle}`, {
-          timeout: 15000,
-        });
+		if (testQuestTitle) {
+			// テストで作成したクエストが表示されるまで待機
+			try {
+				await page.waitForSelector(`text=${testQuestTitle}`, {
+					timeout: 15000,
+				});
 
-        const testQuestCard = page
-          .locator('article, [data-testid="quest-card"], .quest-card')
-          .filter({ hasText: testQuestTitle })
-          .first();
+				const testQuestCard = page
+					.locator('article, [data-testid="quest-card"], .quest-card')
+					.filter({ hasText: testQuestTitle })
+					.first();
 
-        const hasTestQuest = (await testQuestCard.count()) > 0;
-        if (hasTestQuest) {
-          questCard = testQuestCard;
-          firstJoinButton = questCard
-            .getByRole("button", { name: "クエストに参加する" })
-            .first();
-        }
-      } catch {
-        // タイトルが見つからない場合は、既存のクエストを使用
-      }
-    }
+				const hasTestQuest = (await testQuestCard.count()) > 0;
+				if (hasTestQuest) {
+					questCard = testQuestCard;
+					firstJoinButton = questCard
+						.getByRole("button", { name: "クエストに参加する" })
+						.first();
+				}
+			} catch {
+				// タイトルが見つからない場合は、既存のクエストを使用
+			}
+		}
 
-    // テストで作成したクエストが見つからない場合は、既存のクエストを使用
-    if (!firstJoinButton) {
-      firstJoinButton = page
-        .locator('button:has-text("クエストに参加する")')
-        .first();
+		// テストで作成したクエストが見つからない場合は、既存のクエストを使用
+		if (!firstJoinButton) {
+			firstJoinButton = page
+				.locator('button:has-text("クエストに参加する")')
+				.first();
 
-      // ボタンを含むカードを特定（親要素を遡る）
-      questCard = firstJoinButton.locator("..").locator("..").locator("..");
-    }
+			// ボタンを含むカードを特定（親要素を遡る）
+			questCard = firstJoinButton.locator("..").locator("..").locator("..");
+		}
 
-    // ボタンが表示 & 有効になっていることを確認
-    await expect(firstJoinButton).toBeVisible({ timeout: 10000 });
-    await expect(firstJoinButton).toBeEnabled();
+		// ボタンが表示 & 有効になっていることを確認
+		await expect(firstJoinButton).toBeVisible({ timeout: 10000 });
+		await expect(firstJoinButton).toBeEnabled();
 
-    // カード内の最初の見出しを取得
-    const questTitle = await questCard
-      .getByRole("heading")
-      .first()
-      .textContent();
-    expect(questTitle).toBeTruthy();
+		// カード内の最初の見出しを取得
+		const questTitle = await questCard
+			.getByRole("heading")
+			.first()
+			.textContent();
+		expect(questTitle).toBeTruthy();
 
-    // 参加ボタンをクリック → ダイアログの「参加する」をクリック
-    await firstJoinButton.click();
+		// 参加ボタンをクリック → ダイアログの「参加する」をクリック
+		await firstJoinButton.click();
 
-    const dialogJoinButton = page.getByRole("button", { name: "参加する" });
-    await expect(dialogJoinButton).toBeVisible();
+		const dialogJoinButton = page.getByRole("button", { name: "参加する" });
+		await expect(dialogJoinButton).toBeVisible();
 
-    // ダイアログイベントを待機
-    const joinDialogEvent = page.waitForEvent("dialog", { timeout: 15000 });
+		// ダイアログイベントを待機
+		const joinDialogEvent = page.waitForEvent("dialog", { timeout: 15000 });
 
-    // ネットワークリクエストを監視（非同期で実行）
-    const responsePromise = page
-      .waitForResponse(
-        (response) =>
-          response.url().includes("/api/quests/") &&
-          response.url().includes("/participants") &&
-          response.request().method() === "POST",
-        { timeout: 10000 }
-      )
-      .catch(() => null);
+		// ネットワークリクエストを監視（非同期で実行）
+		const responsePromise = page
+			.waitForResponse(
+				(response) =>
+					response.url().includes("/api/quests/") &&
+					response.url().includes("/participants") &&
+					response.request().method() === "POST",
+				{ timeout: 10000 },
+			)
+			.catch(() => null);
 
-    // 参加ボタンをクリック
-    await dialogJoinButton.click();
+		// 参加ボタンをクリック
+		await dialogJoinButton.click();
 
-    // アラートを待機
-    const alert = await joinDialogEvent;
-    const alertMessage = alert.message();
+		// アラートを待機
+		const alert = await joinDialogEvent;
+		const alertMessage = alert.message();
 
-    // APIレスポンスを確認（非ブロッキング）
-    responsePromise
-      .then((response) => {
-        if (response) {
-          console.log("API Response Status:", response.status());
-          response
-            .json()
-            .then((body) => {
-              console.log("API Response Body:", JSON.stringify(body));
-            })
-            .catch(() => {
-              response
-                .text()
-                .then((text) => {
-                  console.log("API Response Body (text):", text);
-                })
-                .catch(() => {});
-            });
-        }
-      })
-      .catch(() => {});
+		// APIレスポンスを確認（非ブロッキング）
+		responsePromise
+			.then((response) => {
+				if (response) {
+					console.log("API Response Status:", response.status());
+					response
+						.json()
+						.then((body) => {
+							console.log("API Response Body:", JSON.stringify(body));
+						})
+						.catch(() => {
+							response
+								.text()
+								.then((text) => {
+									console.log("API Response Body (text):", text);
+								})
+								.catch(() => {});
+						});
+				}
+			})
+			.catch(() => {});
 
-    // エラーメッセージの場合は詳細を出力
-    if (!alertMessage.includes("クエストに参加しました！")) {
-      console.error("Join failed. Alert message:", alertMessage);
-    }
+		// エラーメッセージの場合は詳細を出力
+		if (!alertMessage.includes("クエストに参加しました！")) {
+			console.error("Join failed. Alert message:", alertMessage);
+		}
 
-    expect(alertMessage).toContain("クエストに参加しました！");
-    await alert.accept();
+		expect(alertMessage).toContain("クエストに参加しました！");
+		await alert.accept();
 
-    // マイページで「募集中（参加中）」タブに該当クエストがあることを確認
-    // マイページのAPIレスポンスを監視
-    const mypageResponsePromise = page
-      .waitForResponse(
-        (response) =>
-          response.url().includes("/mypage/entries") &&
-          response.request().method() === "GET",
-        { timeout: 10000 }
-      )
-      .catch(() => null);
+		// マイページで「募集中（参加中）」タブに該当クエストがあることを確認
+		// マイページのAPIレスポンスを監視
+		const mypageResponsePromise = page
+			.waitForResponse(
+				(response) =>
+					response.url().includes("/mypage/entries") &&
+					response.request().method() === "GET",
+				{ timeout: 10000 },
+			)
+			.catch(() => null);
 
-    await page.goto(`${BASE_URL}/mypage`, { waitUntil: "networkidle" });
+		await page.goto(`${BASE_URL}/mypage`, { waitUntil: "networkidle" });
 
-    // ページが読み込まれるまで待機
-    await page.waitForLoadState("networkidle");
+		// ページが読み込まれるまで待機
+		await page.waitForLoadState("networkidle");
 
-    // APIレスポンスを確認
-    const mypageResponse = await mypageResponsePromise;
-    if (mypageResponse) {
-      try {
-        const mypageData = await mypageResponse.json();
-        console.log(
-          "MyPage API Response:",
-          JSON.stringify(mypageData, null, 2)
-        );
-      } catch (err) {
-        console.log("Could not parse mypage response:", err);
-      }
-    }
+		// APIレスポンスを確認
+		const mypageResponse = await mypageResponsePromise;
+		if (mypageResponse) {
+			try {
+				const mypageData = await mypageResponse.json();
+				console.log(
+					"MyPage API Response:",
+					JSON.stringify(mypageData, null, 2),
+				);
+			} catch (err) {
+				console.log("Could not parse mypage response:", err);
+			}
+		}
 
-    // 少し待機してデータが読み込まれるのを待つ
-    await page.waitForTimeout(2000);
+		// 少し待機してデータが読み込まれるのを待つ
+		await page.waitForTimeout(2000);
 
-    // 「募集中」タブをクリック（QuestHistory）
-    await page.getByRole("button", { name: "募集中" }).click();
+		// 「募集中」タブをクリック（QuestHistory）
+		await page.getByRole("button", { name: "募集中" }).click();
 
-    // タブ切り替え後の読み込みを待機
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(1000);
+		// タブ切り替え後の読み込みを待機
+		await page.waitForLoadState("networkidle");
+		await page.waitForTimeout(1000);
 
-    // ページの内容を確認（デバッグ用）
-    const pageContent = await page.content();
-    console.log(
-      "Page contains quest title:",
-      pageContent.includes(questTitle || "")
-    );
+		// ページの内容を確認（デバッグ用）
+		const pageContent = await page.content();
+		console.log(
+			"Page contains quest title:",
+			pageContent.includes(questTitle || ""),
+		);
 
-    // マイページでの確認はオプショナル（参加自体は成功している）
-    // タイミングの問題で表示されない可能性があるため、警告のみ
-    if (questTitle) {
-      const questTitleText = questTitle.trim();
-      const hasQuest =
-        (await page.getByText(questTitleText, { exact: false }).count()) > 0;
-      if (!hasQuest) {
-        console.warn(
-          `Quest title "${questTitleText}" not found in mypage. This may be a timing issue or API issue.`
-        );
-      } else {
-        // 見つかった場合は確認
-        await expect(
-          page.getByText(questTitleText, { exact: false }).first()
-        ).toBeVisible({ timeout: 5000 });
-      }
-    }
-  });
+		// マイページでの確認はオプショナル（参加自体は成功している）
+		// タイミングの問題で表示されない可能性があるため、警告のみ
+		if (questTitle) {
+			const questTitleText = questTitle.trim();
+			const hasQuest =
+				(await page.getByText(questTitleText, { exact: false }).count()) > 0;
+			if (!hasQuest) {
+				console.warn(
+					`Quest title "${questTitleText}" not found in mypage. This may be a timing issue or API issue.`,
+				);
+			} else {
+				// 見つかった場合は確認
+				await expect(
+					page.getByText(questTitleText, { exact: false }).first(),
+				).toBeVisible({ timeout: 5000 });
+			}
+		}
+	});
 
-  test("既に参加中のクエストに重複応募できない", async ({ page }) => {
-    // すでに E2E_USER_EMAIL が何らかのクエストに参加している前提
-    await login(page, USER_EMAIL, USER_PASSWORD);
+	test("既に参加中のクエストに重複応募できない", async ({ page }) => {
+		// すでに E2E_USER_EMAIL が何らかのクエストに参加している前提
+		await login(page, USER_EMAIL, USER_PASSWORD);
 
-    await page.goto(`${BASE_URL}/quests`, { waitUntil: "networkidle" });
+		await page.goto(`${BASE_URL}/quests`, { waitUntil: "networkidle" });
 
-    // 「クエストに参加する」ボタンが表示されるまで待機
-    await page.waitForSelector('button:has-text("クエストに参加する")', {
-      timeout: 15000,
-    });
+		// 「クエストに参加する」ボタンが表示されるまで待機
+		await page.waitForSelector('button:has-text("クエストに参加する")', {
+			timeout: 15000,
+		});
 
-    const firstJoinButton = page
-      .getByRole("button", { name: "クエストに参加する" })
-      .first();
-    await expect(firstJoinButton).toBeVisible({ timeout: 10000 });
+		const firstJoinButton = page
+			.getByRole("button", { name: "クエストに参加する" })
+			.first();
+		await expect(firstJoinButton).toBeVisible({ timeout: 10000 });
 
-    // クエストカードを特定（親要素を遡る方法）
-    const questCard = firstJoinButton.locator("..").locator("..").locator("..");
+		// クエストカードを特定（親要素を遡る方法）
+		const questCard = firstJoinButton.locator("..").locator("..").locator("..");
 
-    // クエストタイトルを取得（最初の見出し）
-    const questTitleLocator = questCard.getByRole("heading").first();
-    await expect(questTitleLocator).toBeVisible({ timeout: 5000 });
-    const questTitle = await questTitleLocator.textContent();
-    expect(questTitle).toBeTruthy();
+		// クエストタイトルを取得（最初の見出し）
+		const questTitleLocator = questCard.getByRole("heading").first();
+		await expect(questTitleLocator).toBeVisible({ timeout: 5000 });
+		const questTitle = await questTitleLocator.textContent();
+		expect(questTitle).toBeTruthy();
 
-    // 1 回目の参加（成功させる）
-    {
-      const joinDialogEvent = page.waitForEvent("dialog");
-      await firstJoinButton.click();
-      const dialogJoinButton = page.getByRole("button", { name: "参加する" });
-      await dialogJoinButton.click();
-      const alert = await joinDialogEvent;
-      // 成功 or 既参加のどちらかになる可能性があるが、
-      // ここでは少なくとも致命的エラーでないことだけを確認
-      await alert.accept();
-    }
+		// 1 回目の参加（成功させる）
+		{
+			const joinDialogEvent = page.waitForEvent("dialog");
+			await firstJoinButton.click();
+			const dialogJoinButton = page.getByRole("button", { name: "参加する" });
+			await dialogJoinButton.click();
+			const alert = await joinDialogEvent;
+			// 成功 or 既参加のどちらかになる可能性があるが、
+			// ここでは少なくとも致命的エラーでないことだけを確認
+			await alert.accept();
+		}
 
-    // 同じクエストに 2 回目の参加を試みる
-    await page.goto(`${BASE_URL}/quests`, { waitUntil: "networkidle" });
+		// 同じクエストに 2 回目の参加を試みる
+		await page.goto(`${BASE_URL}/quests`, { waitUntil: "networkidle" });
 
-    // 同じクエストのボタンを探す（タイトルで特定）
-    const sameQuestJoinButton = page
-      .getByRole("button", { name: "クエストに参加する" })
-      .first();
+		// 同じクエストのボタンを探す（タイトルで特定）
+		const sameQuestJoinButton = page
+			.getByRole("button", { name: "クエストに参加する" })
+			.first();
 
-    const secondDialogEvent = page.waitForEvent("dialog");
-    await sameQuestJoinButton.click();
-    const dialogJoinButton2 = page.getByRole("button", { name: "参加する" });
-    await dialogJoinButton2.click();
+		const secondDialogEvent = page.waitForEvent("dialog");
+		await sameQuestJoinButton.click();
+		const dialogJoinButton2 = page.getByRole("button", { name: "参加する" });
+		await dialogJoinButton2.click();
 
-    const secondAlert = await secondDialogEvent;
-    // 成功メッセージではないこと（= 重複応募が許容されていないこと）を確認
-    expect(secondAlert.message()).not.toContain("クエストに参加しました！");
-    await secondAlert.accept();
+		const secondAlert = await secondDialogEvent;
+		// 成功メッセージではないこと（= 重複応募が許容されていないこと）を確認
+		expect(secondAlert.message()).not.toContain("クエストに参加しました！");
+		await secondAlert.accept();
 
-    // マイページ上で該当クエストが重複していないこと（オプショナル）
-    await page.goto(`${BASE_URL}/mypage`, { waitUntil: "networkidle" });
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(2000);
+		// マイページ上で該当クエストが重複していないこと（オプショナル）
+		await page.goto(`${BASE_URL}/mypage`, { waitUntil: "networkidle" });
+		await page.waitForLoadState("networkidle");
+		await page.waitForTimeout(2000);
 
-    await page.getByRole("button", { name: "募集中" }).click();
-    await page.waitForLoadState("networkidle");
-    await page.waitForTimeout(1000);
+		await page.getByRole("button", { name: "募集中" }).click();
+		await page.waitForLoadState("networkidle");
+		await page.waitForTimeout(1000);
 
-    if (questTitle) {
-      const questTitleText = questTitle.trim();
-      const hasQuest =
-        (await page.getByText(questTitleText, { exact: false }).count()) > 0;
-      if (hasQuest) {
-        // 見つかった場合は1つだけであることを確認
-        const items = page.getByText(questTitleText, { exact: false });
-        await expect(items.first()).toBeVisible({ timeout: 5000 });
-        // 重複チェック（2つ以上ないことを確認）
-        const count = await items.count();
-        expect(count).toBeLessThanOrEqual(1);
-      } else {
-        console.warn(
-          `Quest title "${questTitleText}" not found in mypage. This may be a timing issue or API issue.`
-        );
-      }
-    }
-  });
+		if (questTitle) {
+			const questTitleText = questTitle.trim();
+			const hasQuest =
+				(await page.getByText(questTitleText, { exact: false }).count()) > 0;
+			if (hasQuest) {
+				// 見つかった場合は1つだけであることを確認
+				const items = page.getByText(questTitleText, { exact: false });
+				await expect(items.first()).toBeVisible({ timeout: 5000 });
+				// 重複チェック（2つ以上ないことを確認）
+				const count = await items.count();
+				expect(count).toBeLessThanOrEqual(1);
+			} else {
+				console.warn(
+					`Quest title "${questTitleText}" not found in mypage. This may be a timing issue or API issue.`,
+				);
+			}
+		}
+	});
 });
 
 test.describe("オファー / 承認系 UI（将来実装前提のスケルトン）", () => {
-  test.skip("承認後にステータスが「参加中」に変化する", async ({ page }) => {
-    /**
-     * 現行のフロントエンドには「応募承認」UIが存在しないため、
-     * このテストは将来の実装を想定したスケルトンとして残す。
-     *
-     * 想定フロー:
-     *  1. 一般ユーザーで応募（/quests → 詳細 → 応募）
-     *  2. 管理者で /admin/dashboard にログインし、応募一覧から該当ユーザーを「承認」
-     *  3. 一般ユーザーで /mypage を開き、対象クエストのステータスが「参加中」になっていることを確認
-     */
-    await login(page, ADMIN_EMAIL, ADMIN_PASSWORD);
-    await page.goto(`${BASE_URL}/admin/dashboard`);
-    // TODO: 応募承認 UI 実装後にセレクタを追加
-    await expect(page).toHaveTitle(/ダッシュボード/);
-  });
+	test.skip("承認後にステータスが「参加中」に変化する", async ({ page }) => {
+		/**
+		 * 現行のフロントエンドには「応募承認」UIが存在しないため、
+		 * このテストは将来の実装を想定したスケルトンとして残す。
+		 *
+		 * 想定フロー:
+		 *  1. 一般ユーザーで応募（/quests → 詳細 → 応募）
+		 *  2. 管理者で /admin/dashboard にログインし、応募一覧から該当ユーザーを「承認」
+		 *  3. 一般ユーザーで /mypage を開き、対象クエストのステータスが「参加中」になっていることを確認
+		 */
+		await login(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+		await page.goto(`${BASE_URL}/admin/dashboard`);
+		// TODO: 応募承認 UI 実装後にセレクタを追加
+		await expect(page).toHaveTitle(/ダッシュボード/);
+	});
 
-  test.skip("管理者が特定ユーザーにオファーできる", async ({ page }) => {
-    /**
-     * バックエンドには offer テーブルが存在するが、
-     * 管理画面からオファーを送信する UI コンポーネントはまだ存在しない。
-     *
-     * 将来:
-     *  1. 管理者で /admin/dashboard にログイン
-     *  2. クエスト詳細から「ユーザーにオファー」アクションを実行
-     *  3. 対象ユーザー選択 → 送信
-     *  4. 成功トーストなどを検証
-     */
-    await login(page, ADMIN_EMAIL, ADMIN_PASSWORD);
-    await page.goto(`${BASE_URL}/admin/dashboard`);
-    await expect(page.getByText("クエスト管理")).toBeVisible();
-  });
+	test.skip("管理者が特定ユーザーにオファーできる", async ({ page }) => {
+		/**
+		 * バックエンドには offer テーブルが存在するが、
+		 * 管理画面からオファーを送信する UI コンポーネントはまだ存在しない。
+		 *
+		 * 将来:
+		 *  1. 管理者で /admin/dashboard にログイン
+		 *  2. クエスト詳細から「ユーザーにオファー」アクションを実行
+		 *  3. 対象ユーザー選択 → 送信
+		 *  4. 成功トーストなどを検証
+		 */
+		await login(page, ADMIN_EMAIL, ADMIN_PASSWORD);
+		await page.goto(`${BASE_URL}/admin/dashboard`);
+		await expect(page.getByText("クエスト管理")).toBeVisible();
+	});
 
-  test.skip("オファー通知が届く", async ({ page }) => {
-    /**
-     * /mypage/notifications から取得される通知に
-     * 「オファー」が含まれることを検証するテストのスケルトン。
-     *
-     * 前提:
-     *  - 事前にシード or API 経由で、OFFER_TARGET_EMAIL 宛てのオファー通知を作成しておく。
-     *
-     * フロー:
-     *  1. 対象ユーザーでログイン
-     *  2. /mypage を表示
-     *  3. NotificationList に「オファー」関連のメッセージが表示されていることを確認
-     */
-    await login(page, OFFER_TARGET_EMAIL, USER_PASSWORD);
-    await page.goto(`${BASE_URL}/mypage`);
+	test.skip("オファー通知が届く", async ({ page }) => {
+		/**
+		 * /mypage/notifications から取得される通知に
+		 * 「オファー」が含まれることを検証するテストのスケルトン。
+		 *
+		 * 前提:
+		 *  - 事前にシード or API 経由で、OFFER_TARGET_EMAIL 宛てのオファー通知を作成しておく。
+		 *
+		 * フロー:
+		 *  1. 対象ユーザーでログイン
+		 *  2. /mypage を表示
+		 *  3. NotificationList に「オファー」関連のメッセージが表示されていることを確認
+		 */
+		await login(page, OFFER_TARGET_EMAIL, USER_PASSWORD);
+		await page.goto(`${BASE_URL}/mypage`);
 
-    await expect(page.getByText("通知")).toBeVisible();
-    // TODO: 実際のオファー通知メッセージ形式に合わせて assertion を追加
-  });
+		await expect(page.getByText("通知")).toBeVisible();
+		// TODO: 実際のオファー通知メッセージ形式に合わせて assertion を追加
+	});
 });

--- a/apps/e2e/tests/quest-entry-offer.ui.spec.ts
+++ b/apps/e2e/tests/quest-entry-offer.ui.spec.ts
@@ -45,9 +45,6 @@ test.describe("クエストエントリー UI E2E", () => {
 		rewardIds: [] as number[],
 	};
 
-	// テスト実行ごとのクエストIDを保存（クリーンアップ用）
-	const testQuestIds = new Map<string, number[]>();
-
 	// 各テスト実行ごとに独立したクエストを作成（ブラウザ間の並列実行に対応）
 	test.beforeEach(async () => {
 		// テストユーザーの既存の参加記録をクリーンアップ（重複参加を防ぐため）

--- a/apps/e2e/tests/quest.spec.ts
+++ b/apps/e2e/tests/quest.spec.ts
@@ -1,232 +1,250 @@
-import { test, expect, request, APIRequestContext } from "@playwright/test";
-import { randomUUID } from "crypto";
+import { randomUUID } from "node:crypto";
+import {
+	type APIRequestContext,
+	expect,
+	request,
+	test,
+} from "@playwright/test";
 
-const BASE_URL = process.env.BACKEND_BASE_URL ?? "http://localhost:3001";
+const BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3001";
 
 type QuestPayload = {
-  title: string;
-  description: string;
-  type: string;
-  status?: string;
-  maxParticipants: number;
-  tags: string[];
-  start_date: string;
-  end_date: string;
-  incentive_amount: number;
-  point_amount: number;
-  note: string;
+	title: string;
+	description: string;
+	type: string;
+	status?: string;
+	maxParticipants: number;
+	tags: string[];
+	start_date: string;
+	end_date: string;
+	incentive_amount: number;
+	point_amount: number;
+	note: string;
+};
+
+type QuestListItem = {
+	id: number;
+	title: string;
+	status: string;
+	deleted_at?: string | null;
 };
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("Quest API E2E Test", () => {
-  let apiContext: APIRequestContext;
-  const createdQuestIds = new Set<number>();
-  const deletedQuestIds = new Set<number>();
+	let apiContext: APIRequestContext;
+	const createdQuestIds = new Set<number>();
+	const deletedQuestIds = new Set<number>();
 
-  const uniqueSuffix = randomUUID().slice(0, 8);
-  let primaryQuestId: number | null = null;
-  let softDeletedQuestId: number | null = null;
+	const uniqueSuffix = randomUUID().slice(0, 8);
+	let primaryQuestId: number | null = null;
+	let softDeletedQuestId: number | null = null;
 
-  const buildQuestPayload = (
-    overrides: Partial<QuestPayload> = {}
-  ): QuestPayload => {
-    const now = Date.now();
-    const start = new Date(now + 24 * 60 * 60 * 1000);
-    const end = new Date(now + 8 * 24 * 60 * 60 * 1000);
-    return {
-      title: `E2Eクエスト-${uniqueSuffix}`,
-      description: "E2Eテストで生成したクエストです。",
-      type: "development",
-      status: "pending",
-      maxParticipants: 5,
-      tags: ["e2e", uniqueSuffix],
-      start_date: start.toISOString(),
-      end_date: end.toISOString(),
-      incentive_amount: 5000,
-      point_amount: 150,
-      note: "自動テスト用",
-      ...overrides,
-    };
-  };
+	const buildQuestPayload = (
+		overrides: Partial<QuestPayload> = {},
+	): QuestPayload => {
+		const now = Date.now();
+		const start = new Date(now + 24 * 60 * 60 * 1000);
+		const end = new Date(now + 8 * 24 * 60 * 60 * 1000);
+		return {
+			title: `E2Eクエスト-${uniqueSuffix}`,
+			description: "E2Eテストで生成したクエストです。",
+			type: "development",
+			status: "pending",
+			maxParticipants: 5,
+			tags: ["e2e", uniqueSuffix],
+			start_date: start.toISOString(),
+			end_date: end.toISOString(),
+			incentive_amount: 5000,
+			point_amount: 150,
+			note: "自動テスト用",
+			...overrides,
+		};
+	};
 
-  const createQuest = async (overrides?: Partial<QuestPayload>) => {
-    const payload = buildQuestPayload(overrides);
-    const response = await apiContext.post("/api/quests", {
-      data: payload,
-    });
-    expect(response.ok(), "Quest creation should succeed").toBeTruthy();
-    const body = await response.json();
-    createdQuestIds.add(body.id);
-    return { body, payload };
-  };
+	const createQuest = async (overrides?: Partial<QuestPayload>) => {
+		const payload = buildQuestPayload(overrides);
+		const response = await apiContext.post("/api/quests", {
+			data: payload,
+		});
+		expect(response.ok(), "Quest creation should succeed").toBeTruthy();
+		const body = await response.json();
+		createdQuestIds.add(body.id);
+		return { body, payload };
+	};
 
-  const deleteQuestIfNeeded = async (questId: number) => {
-    if (deletedQuestIds.has(questId)) return;
-    const response = await apiContext.delete(`/api/quests/${questId}`);
-    if (response.ok()) {
-      deletedQuestIds.add(questId);
-    }
-  };
+	const deleteQuestIfNeeded = async (questId: number) => {
+		if (deletedQuestIds.has(questId)) return;
+		const response = await apiContext.delete(`/api/quests/${questId}`);
+		if (response.ok()) {
+			deletedQuestIds.add(questId);
+		}
+	};
 
-  test.beforeAll(async ({ playwright }) => {
-    apiContext = await request.newContext({
-      baseURL: BASE_URL,
-    });
-  });
+	test.beforeAll(async ({ playwright }) => {
+		apiContext = await request.newContext({
+			baseURL: BASE_URL,
+		});
+	});
 
-  test.afterAll(async () => {
-    for (const questId of createdQuestIds) {
-      await deleteQuestIfNeeded(questId);
-    }
-    await apiContext.dispose();
-  });
+	test.afterAll(async () => {
+		for (const questId of createdQuestIds) {
+			await deleteQuestIfNeeded(questId);
+		}
+		await apiContext.dispose();
+	});
 
-  test("POST /api/quests で必須項目を含むクエストを作成できる", async () => {
-    const { body, payload } = await createQuest();
-    primaryQuestId = body.id;
+	test("POST /api/quests で必須項目を含むクエストを作成できる", async () => {
+		const { body, payload } = await createQuest();
+		primaryQuestId = body.id;
 
-    expect(body.title).toBe(payload.title);
-    expect(body.status).toBe(payload.status);
-    expect(body.maxParticipants).toBe(payload.maxParticipants);
-    expect(Array.isArray(body.tags)).toBeTruthy();
-  });
+		expect(body.title).toBe(payload.title);
+		expect(body.status).toBe(payload.status);
+		expect(body.maxParticipants).toBe(payload.maxParticipants);
+		expect(Array.isArray(body.tags)).toBeTruthy();
+	});
 
-  test("POST /api/quests は必須項目欠落時に 400 を返す", async () => {
-    const response = await apiContext.post("/api/quests", {
-      data: {
-        description: "タイトルなし",
-      },
-    });
-    expect(response.status()).toBe(400);
-    const body = await response.json();
-    expect(body.message).toContain("required");
-  });
+	test("POST /api/quests は必須項目欠落時に 400 を返す", async () => {
+		const response = await apiContext.post("/api/quests", {
+			data: {
+				description: "タイトルなし",
+			},
+		});
+		expect(response.status()).toBe(400);
+		const body = await response.json();
+		expect(body.message).toContain("required");
+	});
 
-  test("GET /api/quests は keyword と status パラメータで絞り込みできる", async () => {
-    expect(primaryQuestId).not.toBeNull();
-    const { payload } = await createQuest({
-      title: `E2Eフィルタ-${uniqueSuffix}`,
-      status: "pending",
-    });
+	test("GET /api/quests は keyword と status パラメータで絞り込みできる", async () => {
+		expect(primaryQuestId).not.toBeNull();
+		const { payload } = await createQuest({
+			title: `E2Eフィルタ-${uniqueSuffix}`,
+			status: "pending",
+		});
 
-    const response = await apiContext.get(
-      `/api/quests?keyword=${encodeURIComponent("フィルタ")}&status=pending`
-    );
-    expect(response.ok()).toBeTruthy();
+		const response = await apiContext.get(
+			`/api/quests?keyword=${encodeURIComponent("フィルタ")}&status=pending`,
+		);
+		expect(response.ok()).toBeTruthy();
 
-    const quests = await response.json();
-    const match = quests.find((quest: any) => quest.title === payload.title);
-    expect(match).toBeTruthy();
-    expect(match.status).toBe("pending");
-  });
+		const quests = (await response.json()) as QuestListItem[];
+		const match = quests.find((quest) => quest.title === payload.title);
+		expect(match).toBeTruthy();
+		expect(match.status).toBe("pending");
+	});
 
-  test("PUT /api/quests/:id で詳細情報を更新できる", async () => {
-    expect(primaryQuestId).not.toBeNull();
-    const updatedPayload = buildQuestPayload({
-      title: `E2E更新-${uniqueSuffix}`,
-      description: "更新済み説明",
-      status: "active",
-      note: "更新後ノート",
-    });
+	test("PUT /api/quests/:id で詳細情報を更新できる", async () => {
+		expect(primaryQuestId).not.toBeNull();
+		const updatedPayload = buildQuestPayload({
+			title: `E2E更新-${uniqueSuffix}`,
+			description: "更新済み説明",
+			status: "active",
+			note: "更新後ノート",
+		});
 
-    const response = await apiContext.put(`/api/quests/${primaryQuestId}`, {
-      data: updatedPayload,
-    });
-    expect(response.ok()).toBeTruthy();
+		const response = await apiContext.put(`/api/quests/${primaryQuestId}`, {
+			data: updatedPayload,
+		});
+		expect(response.ok()).toBeTruthy();
 
-    const detailResponse = await apiContext.get(
-      `/api/quests/${primaryQuestId}`
-    );
-    expect(detailResponse.ok()).toBeTruthy();
-    const quest = await detailResponse.json();
-    expect(quest.title).toBe(updatedPayload.title);
-    expect(quest.description).toBe(updatedPayload.description);
-    expect(quest.status).toBe("active");
-  });
+		const detailResponse = await apiContext.get(
+			`/api/quests/${primaryQuestId}`,
+		);
+		expect(detailResponse.ok()).toBeTruthy();
+		const quest = await detailResponse.json();
+		expect(quest.title).toBe(updatedPayload.title);
+		expect(quest.description).toBe(updatedPayload.description);
+		expect(quest.status).toBe("active");
+	});
 
-  test("PATCH /api/quests/:id/status で公開/非公開を切り替えできる", async () => {
-    expect(primaryQuestId).not.toBeNull();
+	test("PATCH /api/quests/:id/status で公開/非公開を切り替えできる", async () => {
+		expect(primaryQuestId).not.toBeNull();
 
-    const deactivate = await apiContext.patch(
-      `/api/quests/${primaryQuestId}/status`,
-      {
-        data: { status: "inactive" },
-      }
-    );
-    expect(deactivate.ok()).toBeTruthy();
-    const inactiveQuest = await deactivate.json();
-    expect(inactiveQuest.status).toBe("inactive");
+		const deactivate = await apiContext.patch(
+			`/api/quests/${primaryQuestId}/status`,
+			{
+				data: { status: "inactive" },
+			},
+		);
+		expect(deactivate.ok()).toBeTruthy();
+		const inactiveQuest = await deactivate.json();
+		expect(inactiveQuest.status).toBe("inactive");
 
-    const reactivate = await apiContext.patch(
-      `/api/quests/${primaryQuestId}/status`,
-      {
-        data: { status: "active" },
-      }
-    );
-    expect(reactivate.ok()).toBeTruthy();
-    const activeQuest = await reactivate.json();
-    expect(activeQuest.status).toBe("active");
-  });
+		const reactivate = await apiContext.patch(
+			`/api/quests/${primaryQuestId}/status`,
+			{
+				data: { status: "active" },
+			},
+		);
+		expect(reactivate.ok()).toBeTruthy();
+		const activeQuest = await reactivate.json();
+		expect(activeQuest.status).toBe("active");
+	});
 
-  test("POST /api/quests/:id/submissions で下書きクエストを承認待ちにできる", async () => {
-    const { body } = await createQuest({
-      title: `E2E承認-${uniqueSuffix}`,
-      status: "draft",
-    });
+	test("POST /api/quests/:id/submissions で下書きクエストを承認待ちにできる", async () => {
+		const { body } = await createQuest({
+			title: `E2E承認-${uniqueSuffix}`,
+			status: "draft",
+		});
 
-    const response = await apiContext.post(`/api/quests/${body.id}/submissions`);
-    expect(response.ok()).toBeTruthy();
-    const result = await response.json();
-    expect(result.quest.status).toBe("pending");
-  });
+		const response = await apiContext.post(
+			`/api/quests/${body.id}/submissions`,
+		);
+		expect(response.ok()).toBeTruthy();
+		const result = await response.json();
+		expect(result.quest.status).toBe("pending");
+	});
 
-  test("DELETE /api/quests/:id でクエストを論理削除し一覧から除外できる", async () => {
-    const { body } = await createQuest({
-      title: `E2E削除-${uniqueSuffix}`,
-      status: "active",
-    });
-    softDeletedQuestId = body.id;
+	test("DELETE /api/quests/:id でクエストを論理削除し一覧から除外できる", async () => {
+		const { body } = await createQuest({
+			title: `E2E削除-${uniqueSuffix}`,
+			status: "active",
+		});
+		softDeletedQuestId = body.id;
 
-    const deleteResponse = await apiContext.delete(
-      `/api/quests/${softDeletedQuestId}`
-    );
-    expect(deleteResponse.ok()).toBeTruthy();
-    deletedQuestIds.add(softDeletedQuestId);
+		const deleteResponse = await apiContext.delete(
+			`/api/quests/${softDeletedQuestId}`,
+		);
+		expect(deleteResponse.ok()).toBeTruthy();
+		deletedQuestIds.add(softDeletedQuestId);
 
-    const listResponse = await apiContext.get("/api/quests");
-    expect(listResponse.ok()).toBeTruthy();
-    const quests = await listResponse.json();
-    const match = quests.find((quest: any) => quest.id === softDeletedQuestId);
-    expect(match).toBeUndefined();
+		const listResponse = await apiContext.get("/api/quests");
+		expect(listResponse.ok()).toBeTruthy();
+		const quests = (await listResponse.json()) as QuestListItem[];
+		const match = quests.find((quest) => quest.id === softDeletedQuestId);
+		expect(match).toBeUndefined();
 
-    const adminResponse = await apiContext.get("/api/quests?includeDeleted=true");
-    expect(adminResponse.ok()).toBeTruthy();
-    const adminQuests = await adminResponse.json();
-    const deletedQuest = adminQuests.find(
-      (quest: any) => quest.id === softDeletedQuestId
-    );
-    expect(deletedQuest).toBeTruthy();
-    expect(deletedQuest.deleted_at).toBeTruthy();
-  });
+		const adminResponse = await apiContext.get(
+			"/api/quests?includeDeleted=true",
+		);
+		expect(adminResponse.ok()).toBeTruthy();
+		const adminQuests = (await adminResponse.json()) as QuestListItem[];
+		const deletedQuest = adminQuests.find(
+			(quest) => quest.id === softDeletedQuestId,
+		);
+		expect(deletedQuest).toBeTruthy();
+		expect(deletedQuest.deleted_at).toBeTruthy();
+	});
 
-  test("POST /api/quests/:id/restorations で論理削除したクエストを復元できる", async () => {
-    if (!softDeletedQuestId) {
-      test.skip(true, "復元対象のクエストがありません");
-    }
-    const response = await apiContext.post(
-      `/api/quests/${softDeletedQuestId}/restorations`
-    );
-    expect(response.ok()).toBeTruthy();
-    const result = await response.json();
-    expect(result.quest.deleted_at).toBeNull();
+	test("POST /api/quests/:id/restorations で論理削除したクエストを復元できる", async () => {
+		if (!softDeletedQuestId) {
+			test.skip(true, "復元対象のクエストがありません");
+		}
+		const response = await apiContext.post(
+			`/api/quests/${softDeletedQuestId}/restorations`,
+		);
+		expect(response.ok()).toBeTruthy();
+		const result = await response.json();
+		expect(result.quest.deleted_at).toBeNull();
 
-    const listResponse = await apiContext.get("/api/quests");
-    const quests = await listResponse.json();
-    const restoredQuest = quests.find(
-      (quest: any) => quest.id === softDeletedQuestId
-    );
-    expect(restoredQuest).toBeTruthy();
-    deletedQuestIds.delete(softDeletedQuestId!);
-  });
+		const listResponse = await apiContext.get("/api/quests");
+		const quests = (await listResponse.json()) as QuestListItem[];
+		const restoredQuest = quests.find(
+			(quest) => quest.id === softDeletedQuestId,
+		);
+		expect(restoredQuest).toBeTruthy();
+		if (softDeletedQuestId) {
+			deletedQuestIds.delete(softDeletedQuestId);
+		}
+	});
 });

--- a/apps/e2e/tests/review.e2e.spec.ts
+++ b/apps/e2e/tests/review.e2e.spec.ts
@@ -1,168 +1,192 @@
-import { test, expect, request } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
-const BASE_URL = "http://localhost:3001"; // バックエンドサーバーのポート
+const BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3001";
 const API_BASE = `${BASE_URL}/api`;
 
-test.describe.serial("レビューAPI E2Eテスト", () => {
-  let questId: number;
-  let userId: number;
-  let reviewId: number;
+type ReviewRecord = {
+	id: number;
+	reviewer_id: number;
+	quest_id?: number;
+	questId?: number;
+};
 
-  test.beforeAll(async ({ request }) => {
-    // 実際に存在するクエストとユーザーを取得
-    const questsResponse = await request.get(`${API_BASE}/quests`);
-    const quests = await questsResponse.json();
-    if (!Array.isArray(quests) || quests.length === 0) {
-      throw new Error("テスト用のクエストが見つかりません。seedデータを実行してください。");
-    }
-    questId = quests[0].id;
+test.describe
+	.serial("レビューAPI E2Eテスト", () => {
+		let questId: number;
+		let userId: number;
+		let reviewId: number;
 
-    const usersResponse = await request.get(`${API_BASE}/users`);
-    const users = await usersResponse.json();
-    if (!Array.isArray(users) || users.length === 0) {
-      throw new Error("テスト用のユーザーが見つかりません。seedデータを実行してください。");
-    }
-    userId = users[0].id;
+		test.beforeAll(async ({ request }) => {
+			// 実際に存在するクエストとユーザーを取得
+			const questsResponse = await request.get(`${API_BASE}/quests`);
+			const quests = await questsResponse.json();
+			if (!Array.isArray(quests) || quests.length === 0) {
+				throw new Error(
+					"テスト用のクエストが見つかりません。seedデータを実行してください。",
+				);
+			}
+			questId = quests[0].id;
 
-    // 念のため古いレビューを削除（存在してもエラーにしない）
-    // まず既存のレビューを確認して削除
-    try {
-      const checkResponse = await request.get(
-        `${API_BASE}/users/${userId}/reviews?questId=${questId}`
-      );
-      if (checkResponse.ok()) {
-        const checkBody = await checkResponse.json();
-        if (checkBody.exists) {
-          // 既存のレビューIDを取得するためにレビュー一覧を取得
-          const reviewsResponse = await request.get(
-            `${API_BASE}/quests/${questId}/reviews`
-          );
-          if (reviewsResponse.ok()) {
-            const reviews = await reviewsResponse.json();
-            const existingReview = reviews.find(
-              (r: any) => r.reviewer_id === userId && (r.quest_id === questId || r.questId === questId)
-            );
-            if (existingReview) {
-              await request.delete(`${API_BASE}/reviews/${existingReview.id}`);
-            }
-          }
-        }
-      }
-    } catch (error) {
-      // エラーは無視
-    }
-  });
+			const usersResponse = await request.get(`${API_BASE}/users`);
+			const users = await usersResponse.json();
+			if (!Array.isArray(users) || users.length === 0) {
+				throw new Error(
+					"テスト用のユーザーが見つかりません。seedデータを実行してください。",
+				);
+			}
+			userId = users[0].id;
 
-  // レビュー作成
-  test("POST /quests/:questId/reviews — 新規レビュー作成できる", async ({
-    request,
-  }) => {
-    const response = await request.post(`${API_BASE}/quests/${questId}/reviews`, {
-      data: {
-        reviewer_id: userId,
-        rating: 4,
-        comment: "とても良いクエストでした！",
-      },
-    });
+			// 念のため古いレビューを削除（存在してもエラーにしない）
+			// まず既存のレビューを確認して削除
+			try {
+				const checkResponse = await request.get(
+					`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
+				);
+				if (checkResponse.ok()) {
+					const checkBody = await checkResponse.json();
+					if (checkBody.exists) {
+						// 既存のレビューIDを取得するためにレビュー一覧を取得
+						const reviewsResponse = await request.get(
+							`${API_BASE}/quests/${questId}/reviews`,
+						);
+						if (reviewsResponse.ok()) {
+							const reviews = (await reviewsResponse.json()) as ReviewRecord[];
+							const existingReview = reviews.find(
+								(r) =>
+									r.reviewer_id === userId &&
+									(r.quest_id === questId || r.questId === questId),
+							);
+							if (existingReview) {
+								await request.delete(
+									`${API_BASE}/reviews/${existingReview.id}`,
+								);
+							}
+						}
+					}
+				}
+			} catch (error) {
+				// エラーは無視
+			}
+		});
 
-    if (response.status() !== 201) {
-      const errorBody = await response.json();
-      console.error("エラーレスポンス:", JSON.stringify(errorBody, null, 2));
-      console.error("questId:", questId, "userId:", userId);
-    }
+		// レビュー作成
+		test("POST /quests/:questId/reviews — 新規レビュー作成できる", async ({
+			request,
+		}) => {
+			const response = await request.post(
+				`${API_BASE}/quests/${questId}/reviews`,
+				{
+					data: {
+						reviewer_id: userId,
+						rating: 4,
+						comment: "とても良いクエストでした！",
+					},
+				},
+			);
 
-    expect(response.status()).toBe(201);
+			if (response.status() !== 201) {
+				const errorBody = await response.json();
+				console.error("エラーレスポンス:", JSON.stringify(errorBody, null, 2));
+				console.error("questId:", questId, "userId:", userId);
+			}
 
-    const body = await response.json();
-    expect(body).toHaveProperty("id");
-    // questIdはquest_idまたはquestIdのどちらかで返される可能性がある
-    expect(body.quest_id || body.questId).toBe(questId);
-    expect(body.reviewer_id).toBe(userId);
+			expect(response.status()).toBe(201);
 
-    reviewId = body.id;
-  });
+			const body = await response.json();
+			expect(body).toHaveProperty("id");
+			// questIdはquest_idまたはquestIdのどちらかで返される可能性がある
+			expect(body.quest_id || body.questId).toBe(questId);
+			expect(body.reviewer_id).toBe(userId);
 
-  // 重複投稿制限
-  test("POST /quests/:questId/reviews — 同一ユーザーは重複投稿できない", async ({
-    request,
-  }) => {
-    const response = await request.post(`${API_BASE}/quests/${questId}/reviews`, {
-      data: {
-        reviewer_id: userId,
-        rating: 5,
-        comment: "再投稿テスト",
-      },
-    });
+			reviewId = body.id;
+		});
 
-    expect(response.status()).toBe(400);
-    const body = await response.json();
-    expect(body.message).toContain("既にレビューを投稿済み");
-  });
+		// 重複投稿制限
+		test("POST /quests/:questId/reviews — 同一ユーザーは重複投稿できない", async ({
+			request,
+		}) => {
+			const response = await request.post(
+				`${API_BASE}/quests/${questId}/reviews`,
+				{
+					data: {
+						reviewer_id: userId,
+						rating: 5,
+						comment: "再投稿テスト",
+					},
+				},
+			);
 
-  // レビュー一覧取得
-  test("GET /quests/:questId/reviews — クエストのレビュー一覧を取得できる", async ({
-    request,
-  }) => {
-    const response = await request.get(`${API_BASE}/quests/${questId}/reviews`);
-    expect(response.status()).toBe(200);
+			expect(response.status()).toBe(400);
+			const body = await response.json();
+			expect(body.message).toContain("既にレビューを投稿済み");
+		});
 
-    const reviews = await response.json();
-    expect(Array.isArray(reviews)).toBe(true);
-    // reviewIdが設定されている場合のみチェック
-    if (reviewId) {
-      expect(reviews.some((r: any) => r.id === reviewId)).toBe(true);
-    }
-  });
+		// レビュー一覧取得
+		test("GET /quests/:questId/reviews — クエストのレビュー一覧を取得できる", async ({
+			request,
+		}) => {
+			const response = await request.get(
+				`${API_BASE}/quests/${questId}/reviews`,
+			);
+			expect(response.status()).toBe(200);
 
-  // レビュー更新
-  test("PUT /reviews/:reviewId — レビューを更新できる", async ({
-    request,
-  }) => {
-    const response = await request.put(`${API_BASE}/reviews/${reviewId}`, {
-      data: {
-        rating: 3,
-        comment: "やや難しかったが楽しい！",
-      },
-    });
+			const reviews = (await response.json()) as ReviewRecord[];
+			expect(Array.isArray(reviews)).toBe(true);
+			// reviewIdが設定されている場合のみチェック
+			if (reviewId) {
+				expect(reviews.some((r) => r.id === reviewId)).toBe(true);
+			}
+		});
 
-    expect(response.status()).toBe(200);
-    const updated = await response.json();
-    // ratingはDecimal型なので、数値として比較
-    expect(Number(updated.rating)).toBe(3);
-    expect(updated.comment).toContain("楽しい");
-  });
+		// レビュー更新
+		test("PUT /reviews/:reviewId — レビューを更新できる", async ({
+			request,
+		}) => {
+			const response = await request.put(`${API_BASE}/reviews/${reviewId}`, {
+				data: {
+					rating: 3,
+					comment: "やや難しかったが楽しい！",
+				},
+			});
 
-  // 投稿済み確認
-  test("GET /users/:userId/reviews?questId=:questId — 投稿済みか確認できる", async ({
-    request,
-  }) => {
-    const response = await request.get(
-      `${API_BASE}/users/${userId}/reviews?questId=${questId}`
-    );
-    expect(response.status()).toBe(200);
+			expect(response.status()).toBe(200);
+			const updated = await response.json();
+			// ratingはDecimal型なので、数値として比較
+			expect(Number(updated.rating)).toBe(3);
+			expect(updated.comment).toContain("楽しい");
+		});
 
-    const body = await response.json();
-    expect(body.exists).toBe(true);
-  });
+		// 投稿済み確認
+		test("GET /users/:userId/reviews?questId=:questId — 投稿済みか確認できる", async ({
+			request,
+		}) => {
+			const response = await request.get(
+				`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
+			);
+			expect(response.status()).toBe(200);
 
-  // レビュー削除
-  test("DELETE /reviews/:reviewId — レビューを削除できる", async ({
-    request,
-  }) => {
-    const response = await request.delete(`${API_BASE}/reviews/${reviewId}`);
-    expect(response.status()).toBe(204);
-  });
+			const body = await response.json();
+			expect(body.exists).toBe(true);
+		});
 
-  // 削除後確認
-  test("GET /users/:userId/reviews?questId=:questId — 削除後はfalseになる", async ({
-    request,
-  }) => {
-    const response = await request.get(
-      `${API_BASE}/users/${userId}/reviews?questId=${questId}`
-    );
-    expect(response.status()).toBe(200);
+		// レビュー削除
+		test("DELETE /reviews/:reviewId — レビューを削除できる", async ({
+			request,
+		}) => {
+			const response = await request.delete(`${API_BASE}/reviews/${reviewId}`);
+			expect(response.status()).toBe(204);
+		});
 
-    const body = await response.json();
-    expect(body.exists).toBe(false);
-  });
-});
+		// 削除後確認
+		test("GET /users/:userId/reviews?questId=:questId — 削除後はfalseになる", async ({
+			request,
+		}) => {
+			const response = await request.get(
+				`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
+			);
+			expect(response.status()).toBe(200);
+
+			const body = await response.json();
+			expect(body.exists).toBe(false);
+		});
+	});

--- a/apps/e2e/tests/review.e2e.spec.ts
+++ b/apps/e2e/tests/review.e2e.spec.ts
@@ -10,183 +10,178 @@ type ReviewRecord = {
 	questId?: number;
 };
 
-test.describe
-	.serial("レビューAPI E2Eテスト", () => {
-		let questId: number;
-		let userId: number;
-		let reviewId: number;
+test.describe.configure({ mode: "serial" });
 
-		test.beforeAll(async ({ request }) => {
-			// 実際に存在するクエストとユーザーを取得
-			const questsResponse = await request.get(`${API_BASE}/quests`);
-			const quests = await questsResponse.json();
-			if (!Array.isArray(quests) || quests.length === 0) {
-				throw new Error(
-					"テスト用のクエストが見つかりません。seedデータを実行してください。",
-				);
-			}
-			questId = quests[0].id;
+test.describe("レビューAPI E2Eテスト", () => {
+	let questId: number;
+	let userId: number;
+	let reviewId: number;
 
-			const usersResponse = await request.get(`${API_BASE}/users`);
-			const users = await usersResponse.json();
-			if (!Array.isArray(users) || users.length === 0) {
-				throw new Error(
-					"テスト用のユーザーが見つかりません。seedデータを実行してください。",
-				);
-			}
-			userId = users[0].id;
+	test.beforeAll(async ({ request }) => {
+		// 実際に存在するクエストとユーザーを取得
+		const questsResponse = await request.get(`${API_BASE}/quests`);
+		const quests = await questsResponse.json();
+		if (!Array.isArray(quests) || quests.length === 0) {
+			throw new Error(
+				"テスト用のクエストが見つかりません。seedデータを実行してください。",
+			);
+		}
+		questId = quests[0].id;
 
-			// 念のため古いレビューを削除（存在してもエラーにしない）
-			// まず既存のレビューを確認して削除
-			try {
-				const checkResponse = await request.get(
-					`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
-				);
-				if (checkResponse.ok()) {
-					const checkBody = await checkResponse.json();
-					if (checkBody.exists) {
-						// 既存のレビューIDを取得するためにレビュー一覧を取得
-						const reviewsResponse = await request.get(
-							`${API_BASE}/quests/${questId}/reviews`,
+		const usersResponse = await request.get(`${API_BASE}/users`);
+		const users = await usersResponse.json();
+		if (!Array.isArray(users) || users.length === 0) {
+			throw new Error(
+				"テスト用のユーザーが見つかりません。seedデータを実行してください。",
+			);
+		}
+		userId = users[0].id;
+
+		// 念のため古いレビューを削除（存在してもエラーにしない）
+		// まず既存のレビューを確認して削除
+		try {
+			const checkResponse = await request.get(
+				`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
+			);
+			if (checkResponse.ok()) {
+				const checkBody = await checkResponse.json();
+				if (checkBody.exists) {
+					// 既存のレビューIDを取得するためにレビュー一覧を取得
+					const reviewsResponse = await request.get(
+						`${API_BASE}/quests/${questId}/reviews`,
+					);
+					if (reviewsResponse.ok()) {
+						const reviews = (await reviewsResponse.json()) as ReviewRecord[];
+						const existingReview = reviews.find(
+							(r) =>
+								r.reviewer_id === userId &&
+								(r.quest_id === questId || r.questId === questId),
 						);
-						if (reviewsResponse.ok()) {
-							const reviews = (await reviewsResponse.json()) as ReviewRecord[];
-							const existingReview = reviews.find(
-								(r) =>
-									r.reviewer_id === userId &&
-									(r.quest_id === questId || r.questId === questId),
-							);
-							if (existingReview) {
-								await request.delete(
-									`${API_BASE}/reviews/${existingReview.id}`,
-								);
-							}
+						if (existingReview) {
+							await request.delete(`${API_BASE}/reviews/${existingReview.id}`);
 						}
 					}
 				}
-			} catch (error) {
-				// エラーは無視
 			}
-		});
-
-		// レビュー作成
-		test("POST /quests/:questId/reviews — 新規レビュー作成できる", async ({
-			request,
-		}) => {
-			const response = await request.post(
-				`${API_BASE}/quests/${questId}/reviews`,
-				{
-					data: {
-						reviewer_id: userId,
-						rating: 4,
-						comment: "とても良いクエストでした！",
-					},
-				},
-			);
-
-			if (response.status() !== 201) {
-				const errorBody = await response.json();
-				console.error("エラーレスポンス:", JSON.stringify(errorBody, null, 2));
-				console.error("questId:", questId, "userId:", userId);
-			}
-
-			expect(response.status()).toBe(201);
-
-			const body = await response.json();
-			expect(body).toHaveProperty("id");
-			// questIdはquest_idまたはquestIdのどちらかで返される可能性がある
-			expect(body.quest_id || body.questId).toBe(questId);
-			expect(body.reviewer_id).toBe(userId);
-
-			reviewId = body.id;
-		});
-
-		// 重複投稿制限
-		test("POST /quests/:questId/reviews — 同一ユーザーは重複投稿できない", async ({
-			request,
-		}) => {
-			const response = await request.post(
-				`${API_BASE}/quests/${questId}/reviews`,
-				{
-					data: {
-						reviewer_id: userId,
-						rating: 5,
-						comment: "再投稿テスト",
-					},
-				},
-			);
-
-			expect(response.status()).toBe(400);
-			const body = await response.json();
-			expect(body.message).toContain("既にレビューを投稿済み");
-		});
-
-		// レビュー一覧取得
-		test("GET /quests/:questId/reviews — クエストのレビュー一覧を取得できる", async ({
-			request,
-		}) => {
-			const response = await request.get(
-				`${API_BASE}/quests/${questId}/reviews`,
-			);
-			expect(response.status()).toBe(200);
-
-			const reviews = (await response.json()) as ReviewRecord[];
-			expect(Array.isArray(reviews)).toBe(true);
-			// reviewIdが設定されている場合のみチェック
-			if (reviewId) {
-				expect(reviews.some((r) => r.id === reviewId)).toBe(true);
-			}
-		});
-
-		// レビュー更新
-		test("PUT /reviews/:reviewId — レビューを更新できる", async ({
-			request,
-		}) => {
-			const response = await request.put(`${API_BASE}/reviews/${reviewId}`, {
-				data: {
-					rating: 3,
-					comment: "やや難しかったが楽しい！",
-				},
-			});
-
-			expect(response.status()).toBe(200);
-			const updated = await response.json();
-			// ratingはDecimal型なので、数値として比較
-			expect(Number(updated.rating)).toBe(3);
-			expect(updated.comment).toContain("楽しい");
-		});
-
-		// 投稿済み確認
-		test("GET /users/:userId/reviews?questId=:questId — 投稿済みか確認できる", async ({
-			request,
-		}) => {
-			const response = await request.get(
-				`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
-			);
-			expect(response.status()).toBe(200);
-
-			const body = await response.json();
-			expect(body.exists).toBe(true);
-		});
-
-		// レビュー削除
-		test("DELETE /reviews/:reviewId — レビューを削除できる", async ({
-			request,
-		}) => {
-			const response = await request.delete(`${API_BASE}/reviews/${reviewId}`);
-			expect(response.status()).toBe(204);
-		});
-
-		// 削除後確認
-		test("GET /users/:userId/reviews?questId=:questId — 削除後はfalseになる", async ({
-			request,
-		}) => {
-			const response = await request.get(
-				`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
-			);
-			expect(response.status()).toBe(200);
-
-			const body = await response.json();
-			expect(body.exists).toBe(false);
-		});
+		} catch (error) {
+			// エラーは無視
+		}
 	});
+
+	// レビュー作成
+	test("POST /quests/:questId/reviews — 新規レビュー作成できる", async ({
+		request,
+	}) => {
+		const response = await request.post(
+			`${API_BASE}/quests/${questId}/reviews`,
+			{
+				data: {
+					reviewer_id: userId,
+					rating: 4,
+					comment: "とても良いクエストでした！",
+				},
+			},
+		);
+
+		if (response.status() !== 201) {
+			const errorBody = await response.json();
+			console.error("エラーレスポンス:", JSON.stringify(errorBody, null, 2));
+			console.error("questId:", questId, "userId:", userId);
+		}
+
+		expect(response.status()).toBe(201);
+
+		const body = await response.json();
+		expect(body).toHaveProperty("id");
+		// questIdはquest_idまたはquestIdのどちらかで返される可能性がある
+		expect(body.quest_id || body.questId).toBe(questId);
+		expect(body.reviewer_id).toBe(userId);
+
+		reviewId = body.id;
+	});
+
+	// 重複投稿制限
+	test("POST /quests/:questId/reviews — 同一ユーザーは重複投稿できない", async ({
+		request,
+	}) => {
+		const response = await request.post(
+			`${API_BASE}/quests/${questId}/reviews`,
+			{
+				data: {
+					reviewer_id: userId,
+					rating: 5,
+					comment: "再投稿テスト",
+				},
+			},
+		);
+
+		expect(response.status()).toBe(400);
+		const body = await response.json();
+		expect(body.message).toContain("既にレビューを投稿済み");
+	});
+
+	// レビュー一覧取得
+	test("GET /quests/:questId/reviews — クエストのレビュー一覧を取得できる", async ({
+		request,
+	}) => {
+		const response = await request.get(`${API_BASE}/quests/${questId}/reviews`);
+		expect(response.status()).toBe(200);
+
+		const reviews = (await response.json()) as ReviewRecord[];
+		expect(Array.isArray(reviews)).toBe(true);
+		// reviewIdが設定されている場合のみチェック
+		if (reviewId) {
+			expect(reviews.some((r) => r.id === reviewId)).toBe(true);
+		}
+	});
+
+	// レビュー更新
+	test("PUT /reviews/:reviewId — レビューを更新できる", async ({ request }) => {
+		const response = await request.put(`${API_BASE}/reviews/${reviewId}`, {
+			data: {
+				rating: 3,
+				comment: "やや難しかったが楽しい！",
+			},
+		});
+
+		expect(response.status()).toBe(200);
+		const updated = await response.json();
+		// ratingはDecimal型なので、数値として比較
+		expect(Number(updated.rating)).toBe(3);
+		expect(updated.comment).toContain("楽しい");
+	});
+
+	// 投稿済み確認
+	test("GET /users/:userId/reviews?questId=:questId — 投稿済みか確認できる", async ({
+		request,
+	}) => {
+		const response = await request.get(
+			`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
+		);
+		expect(response.status()).toBe(200);
+
+		const body = await response.json();
+		expect(body.exists).toBe(true);
+	});
+
+	// レビュー削除
+	test("DELETE /reviews/:reviewId — レビューを削除できる", async ({
+		request,
+	}) => {
+		const response = await request.delete(`${API_BASE}/reviews/${reviewId}`);
+		expect(response.status()).toBe(204);
+	});
+
+	// 削除後確認
+	test("GET /users/:userId/reviews?questId=:questId — 削除後はfalseになる", async ({
+		request,
+	}) => {
+		const response = await request.get(
+			`${API_BASE}/users/${userId}/reviews?questId=${questId}`,
+		);
+		expect(response.status()).toBe(200);
+
+		const body = await response.json();
+		expect(body.exists).toBe(false);
+	});
+});

--- a/apps/e2e/tests/role-api.spec.ts
+++ b/apps/e2e/tests/role-api.spec.ts
@@ -1,63 +1,69 @@
 // e2e/tests/role-api.spec.ts
-import { test, expect, request } from "@playwright/test";
+import { expect, request, test } from "@playwright/test";
 import { testUsers } from "../fixtures/users";
 
+const API_BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3001";
+
 const getIdToken = async (page, email, password) => {
-  // alertダイアログを待機
-  const dialogPromise = page.waitForEvent("dialog");
+	// alertダイアログを待機
+	const dialogPromise = page.waitForEvent("dialog");
 
-  await page.goto("/login");
+	await page.goto("/login");
 
-  // placeholderでinputを特定（name属性がないため）
-  await page.getByPlaceholder("メールアドレス").fill(email);
-  await page.getByPlaceholder("パスワード").fill(password);
+	// placeholderでinputを特定（name属性がないため）
+	await page.getByPlaceholder("メールアドレス").fill(email);
+	await page.getByPlaceholder("パスワード").fill(password);
 
-  // ログインボタンをクリック（type="submit"ではなくonClickハンドラー）
-  await page.getByRole("button", { name: "ログイン" }).click();
+	// ログインボタンをクリック（type="submit"ではなくonClickハンドラー）
+	await page.getByRole("button", { name: "ログイン" }).click();
 
-  // ダイアログを待機して閉じる
-  const dialog = await dialogPromise;
-  await dialog.accept();
+	// ダイアログを待機して閉じる
+	const dialog = await dialogPromise;
+	await dialog.accept();
 
-  // ログイン成功後は"/"に遷移することを確認
-  await page.waitForURL("/", { timeout: 10000 });
+	// ログイン成功後は"/"に遷移することを確認
+	await page.waitForURL("/", { timeout: 10000 });
 
-  const token = await page.evaluate(() => {
-    return window.localStorage.getItem("authToken");
-  });
+	const token = await page.evaluate(() => {
+		return window.localStorage.getItem("authToken");
+	});
 
-  return token;
+	return token;
 };
 
 test.describe("API ロール制御", () => {
-// TODO: 一般ユーザーはユーザー一覧を取得できない処理を追加する
-  // test("一般ユーザーはユーザー一覧を取得できない", async ({ page }) => {
-  //   const token = await getIdToken(page, testUsers.user.email, testUsers.user.password);
+	// TODO: 一般ユーザーはユーザー一覧を取得できない処理を追加する
+	// test("一般ユーザーはユーザー一覧を取得できない", async ({ page }) => {
+	//   const token = await getIdToken(page, testUsers.user.email, testUsers.user.password);
 
-  //   const api = await request.newContext({
-  //     baseURL: "http://localhost:3001",
-  //     extraHTTPHeaders: {
-  //       Authorization: `Bearer ${token}`,
-  //     },
-  //   });
+	//   const api = await request.newContext({
+	//     baseURL: "http://localhost:3001",
+	//     extraHTTPHeaders: {
+	//       Authorization: `Bearer ${token}`,
+	//     },
+	//   });
 
-  //   const res = await api.get("/api/admin/users");
+	//   const res = await api.get("/api/admin/users");
 
-  //   expect(res.status()).toBe(403);
-  // });
+	//   expect(res.status()).toBe(403);
+	// });
 
-  test("マネージャーはユーザー一覧を取得できる", async ({ page }) => {
-    const token = await getIdToken(page, testUsers.manager.email, testUsers.manager.password);
+	test("マネージャーはユーザー一覧を取得できる", async ({ page }) => {
+		const token = await getIdToken(
+			page,
+			testUsers.manager.email,
+			testUsers.manager.password,
+		);
 
-    const api = await request.newContext({
-      baseURL: "http://localhost:3001",
-      extraHTTPHeaders: {
-        Authorization: `Bearer ${token}`,
-      },
-    });
+		const api = await request.newContext({
+			baseURL: API_BASE_URL,
+			extraHTTPHeaders: {
+				Authorization: `Bearer ${token}`,
+			},
+		});
 
-    const res = await api.get("/api/admin/users");
+		const res = await api.get("/api/admin/users");
 
-    expect(res.status()).toBe(200);
-  });
+		expect(res.status()).toBe(200);
+	});
 });

--- a/apps/e2e/tests/user.spec.ts
+++ b/apps/e2e/tests/user.spec.ts
@@ -1,132 +1,132 @@
+import { randomUUID } from "node:crypto";
 // @ts-nocheck
 import {
-  test,
-  expect,
-  request,
-  type APIRequestContext,
+	type APIRequestContext,
+	expect,
+	request,
+	test,
 } from "@playwright/test";
 import { PrismaClient } from "@prisma/client";
-import { randomUUID } from "crypto";
 
-const BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3000";
+const BASE_URL = process.env.API_BASE_URL ?? "http://localhost:3001";
 
 test.describe.configure({ mode: "serial" });
 
 test.describe("User Management API E2E Test", () => {
-  let apiContext: APIRequestContext;
-  const prisma = new PrismaClient();
-  let createdUserId: number;
-  let createdUserEmail: string;
-  let createdUserName: string;
-  let shouldCleanup = false;
+	let apiContext: APIRequestContext;
+	const prisma = new PrismaClient();
+	let createdUserId: number;
+	let createdUserEmail: string;
+	let createdUserName: string;
+	let shouldCleanup = false;
 
-  test.beforeAll(async () => {
-    apiContext = await request.newContext({
-      baseURL: BASE_URL,
-    });
+	test.beforeAll(async () => {
+		apiContext = await request.newContext({
+			baseURL: BASE_URL,
+		});
 
-    const uniqueSuffix = randomUUID();
+		const uniqueSuffix = randomUUID();
 
-    const user = await prisma.user.create({
-      data: {
-        name: `e2e-user-${uniqueSuffix.slice(0, 8)}`,
-        email: `e2e-user-${uniqueSuffix}@example.com`,
-        role: "user",
-      },
-    });
+		const user = await prisma.user.create({
+			data: {
+				name: `e2e-user-${uniqueSuffix.slice(0, 8)}`,
+				email: `e2e-user-${uniqueSuffix}@example.com`,
+				role: "user",
+			},
+		});
 
-    createdUserId = user.id;
-    createdUserEmail = user.email;
-    createdUserName = user.name;
-    shouldCleanup = true;
-  });
+		createdUserId = user.id;
+		createdUserEmail = user.email;
+		createdUserName = user.name;
+		shouldCleanup = true;
+	});
 
-  test.afterAll(async () => {
-    if (shouldCleanup) {
-      await prisma.user
-        .delete({ where: { id: createdUserId } })
-        .catch(() => {});
-    }
-    await prisma.$disconnect();
-    await apiContext.dispose();
-  });
+	test.afterAll(async () => {
+		if (shouldCleanup) {
+			await prisma.user
+				.delete({ where: { id: createdUserId } })
+				.catch(() => {});
+		}
+		await prisma.$disconnect();
+		await apiContext.dispose();
+	});
 
-  test("GET /api/users?email=... でユーザー情報を取得できる", async () => {
-    const response = await apiContext.get(
-      `/api/users?email=${encodeURIComponent(createdUserEmail)}`
-    );
+	test("GET /api/users?email=... でユーザー情報を取得できる", async () => {
+		const response = await apiContext.get(
+			`/api/users?email=${encodeURIComponent(createdUserEmail)}`,
+		);
 
-    expect(response.ok()).toBeTruthy();
-    const body = await response.json();
+		expect(response.ok()).toBeTruthy();
+		const body = await response.json();
 
-    expect(body[0]).toMatchObject({
-      id: createdUserId,
-      name: createdUserName,
-      email: createdUserEmail,
-    });
-  });
+		expect(body[0]).toMatchObject({
+			id: createdUserId,
+			name: createdUserName,
+			email: createdUserEmail,
+		});
+	});
 
-  test("GET /api/users?name=... の結果からユーザーIDを取得できる", async () => {
-    const response = await apiContext.get(
-      `/api/users?name=${encodeURIComponent(createdUserName)}`
-    );
+	test("GET /api/users?name=... の結果からユーザーIDを取得できる", async () => {
+		const response = await apiContext.get(
+			`/api/users?name=${encodeURIComponent(createdUserName)}`,
+		);
 
-    expect(response.ok()).toBeTruthy();
-    const body = await response.json();
-    expect(body[0]?.id).toBe(createdUserId);
-  });
+		expect(response.ok()).toBeTruthy();
+		const body = await response.json();
+		expect(body[0]?.id).toBe(createdUserId);
+	});
 
-  test("GET /api/users で対象ユーザーが含まれている", async () => {
-    const response = await apiContext.get("/api/users");
-    expect(response.ok()).toBeTruthy();
+	test("GET /api/users で対象ユーザーが含まれている", async () => {
+		const response = await apiContext.get("/api/users");
+		expect(response.ok()).toBeTruthy();
 
-    const users = (await response.json()) as Array<{
-      id: number;
-      email: string;
-    }>;
-    const found = users.find((user) => user.id === createdUserId);
-    expect(found).toBeTruthy();
-    expect(found?.email).toBe(createdUserEmail);
-  });
+		const users = (await response.json()) as Array<{
+			id: number;
+			email: string;
+		}>;
+		const found = users.find((user) => user.id === createdUserId);
+		expect(found).toBeTruthy();
+		expect(found?.email).toBe(createdUserEmail);
+	});
 
-  test("PUT /api/admin/users/:id/role でユーザーのロールを更新できる", async () => {
-    const response = await apiContext.put(
-      `/api/admin/users/${createdUserId}/role`,
-      {
-        data: { role: "admin" },
-      }
-    );
+	test("PUT /api/admin/users/:id/role でユーザーのロールを更新できる", async () => {
+		const response = await apiContext.put(
+			`/api/admin/users/${createdUserId}/role`,
+			{
+				data: { role: "admin" },
+			},
+		);
 
-    expect(response.ok()).toBeTruthy();
-    const body = await response.json();
-    expect(body.user.role).toBe("admin");
+		expect(response.ok()).toBeTruthy();
+		const body = await response.json();
+		expect(body.user.role).toBe("admin");
 
-    const updatedUser = await prisma.user.findUnique({
-      where: { id: createdUserId },
-    });
-    expect(updatedUser?.role).toBe("admin");
-  });
+		const updatedUser = await prisma.user.findUnique({
+			where: { id: createdUserId },
+		});
+		expect(updatedUser?.role).toBe("admin");
+	});
 
-  test("DELETE /api/users/:id でユーザーを削除できる", async () => {
-    const response = await apiContext.delete(`/api/users/${createdUserId}`);
+	test("DELETE /api/users/:id でユーザーを削除できる", async () => {
+		const response = await apiContext.delete(`/api/users/${createdUserId}`);
 
-    expect(response.ok()).toBeTruthy();
+		expect(response.ok()).toBeTruthy();
 
-    const body = await response.json();
-    expect(body.message).toBe("User deleted successfully");
-    expect(body.user.id).toBe(createdUserId);
+		const body = await response.json();
+		expect(body.message).toBe("User deleted successfully");
+		expect(body.user.id).toBe(createdUserId);
 
-    const deletedUser = await prisma.user.findUnique({
-      where: { id: createdUserId },
-    });
-    expect(deletedUser).toBeNull();
+		const deletedUser = await prisma.user.findUnique({
+			where: { id: createdUserId },
+		});
+		expect(deletedUser).toBeNull();
 
-    shouldCleanup = false;
+		shouldCleanup = false;
 
-    const notFound = await apiContext.get(
-      `/api/users?email=${encodeURIComponent(createdUserEmail)}`
-    );
-    expect(notFound.ok()).toBeTruthy();
-    expect(await notFound.json()).toEqual([]);
-  });
+		const notFound = await apiContext.get(
+			`/api/users?email=${encodeURIComponent(createdUserEmail)}`,
+		);
+		expect(notFound.ok()).toBeTruthy();
+		expect(await notFound.json()).toEqual([]);
+	});
 });

--- a/apps/frontend/src/__tests__/constants/questPresentation.test.ts
+++ b/apps/frontend/src/__tests__/constants/questPresentation.test.ts
@@ -1,0 +1,49 @@
+import {
+	HIDDEN_QUEST_STATUSES,
+	getQuestDifficultyBadgeClass,
+	getQuestRibbonStatus,
+	getQuestStatusBadgeClass,
+	getQuestStatusLabel,
+	getQuestTypeIconKind,
+} from "@/constants/questPresentation";
+import { QuestDifficulty, QuestStatus, QuestType } from "@quest-board/types";
+import { describe, expect, it } from "vitest";
+
+describe("questPresentation", () => {
+	it("status の表示ラベルと色クラスを返す", () => {
+		expect(getQuestStatusLabel(QuestStatus.Pending)).toBe("承認待ち");
+		expect(getQuestStatusBadgeClass(QuestStatus.Pending)).toBe("bg-yellow-500");
+	});
+
+	it("未知の status はフォールバック値を返す", () => {
+		expect(getQuestStatusLabel("unknown_status")).toBe("unknown_status");
+		expect(getQuestStatusBadgeClass("unknown_status")).toBe("bg-gray-500");
+	});
+
+	it("difficulty から色クラスを返す", () => {
+		expect(getQuestDifficultyBadgeClass(QuestDifficulty.Beginner)).toBe(
+			"bg-green-500",
+		);
+		expect(getQuestDifficultyBadgeClass(undefined)).toBe("bg-gray-500");
+	});
+
+	it("type からアイコン種別を返す", () => {
+		expect(getQuestTypeIconKind(QuestType.Development)).toBe("wrench");
+		expect(getQuestTypeIconKind(QuestType.Learning)).toBe("book");
+		expect(getQuestTypeIconKind(QuestType.Design)).toBe("sword");
+	});
+
+	it("status から ribbon 表示状態を返す", () => {
+		expect(getQuestRibbonStatus(QuestStatus.Active)).toBe("participating");
+		expect(getQuestRibbonStatus(QuestStatus.Completed)).toBe("completed");
+		expect(getQuestRibbonStatus("pending")).toBe("applied");
+	});
+
+	it("一般ユーザーに非表示の status 一覧を持つ", () => {
+		expect(HIDDEN_QUEST_STATUSES).toEqual([
+			QuestStatus.Draft,
+			QuestStatus.Pending,
+			QuestStatus.Inactive,
+		]);
+	});
+});

--- a/apps/frontend/src/__tests__/hooks/useMyPageData.test.ts
+++ b/apps/frontend/src/__tests__/hooks/useMyPageData.test.ts
@@ -1,65 +1,70 @@
 import { describe, expect, it, vi } from "vitest";
 
 vi.mock("@/services/httpClient", () => ({
-  authenticatedHttpRequest: vi.fn(),
+	authenticatedHttpRequest: vi.fn(),
 }));
 
 vi.mock("@/services/quest", () => ({
-  questService: {
-    getAllQuests: vi.fn(),
-  },
+	questService: {
+		getAllQuests: vi.fn(),
+	},
 }));
 
 import {
-  categorizeQuestsByStatus,
-  toDisplayNotification,
+	categorizeQuestsByStatus,
+	toDisplayNotification,
 } from "@/hooks/useMyPageData";
-import { QuestDifficulty, QuestStatus, QuestType, type Quest } from "@/types/quest";
+import {
+	type Quest,
+	QuestDifficulty,
+	QuestStatus,
+	QuestType,
+} from "@quest-board/types";
 
 const createQuest = (overrides: Partial<Quest>): Quest => ({
-  id: 1,
-  title: "quest",
-  description: "desc",
-  type: QuestType.Development,
-  status: QuestStatus.Active,
-  start_date: "2024-01-01T00:00:00Z",
-  end_date: "2024-12-31T00:00:00Z",
-  created_at: "2024-01-01T00:00:00Z",
-  updated_at: "2024-01-01T00:00:00Z",
-  rewards: { incentive_amount: 1000, point_amount: 100, note: "" },
-  quest_participants: [],
-  _count: { quest_participants: 0 },
-  maxParticipants: 5,
-  tags: [],
-  difficulty: QuestDifficulty.Beginner,
-  ...overrides,
+	id: 1,
+	title: "quest",
+	description: "desc",
+	type: QuestType.Development,
+	status: QuestStatus.Active,
+	start_date: "2024-01-01T00:00:00Z",
+	end_date: "2024-12-31T00:00:00Z",
+	created_at: "2024-01-01T00:00:00Z",
+	updated_at: "2024-01-01T00:00:00Z",
+	rewards: { incentive_amount: 1000, point_amount: 100, note: "" },
+	quest_participants: [],
+	_count: { quest_participants: 0 },
+	maxParticipants: 5,
+	tags: [],
+	difficulty: QuestDifficulty.Beginner,
+	...overrides,
 });
 
 describe("useMyPageData helpers", () => {
-  it("通知レスポンスを表示用の型へ変換する", () => {
-    const result = toDisplayNotification({
-      id: 10,
-      message: "通知",
-      isRead: false,
-      createdAt: "2024-01-01T12:34:56Z",
-    });
+	it("通知レスポンスを表示用の型へ変換する", () => {
+		const result = toDisplayNotification({
+			id: 10,
+			message: "通知",
+			isRead: false,
+			createdAt: "2024-01-01T12:34:56Z",
+		});
 
-    expect(result.id).toBe(10);
-    expect(result.message).toBe("通知");
-    expect(result.type).toBe("info");
-    expect(result.timestamp).toContain("2024");
-  });
+		expect(result.id).toBe(10);
+		expect(result.message).toBe("通知");
+		expect(result.type).toBe("info");
+		expect(result.timestamp).toContain("2024");
+	});
 
-  it("クエストを status ごとに分類する", () => {
-    const result = categorizeQuestsByStatus([
-      createQuest({ id: 1, status: QuestStatus.Active }),
-      createQuest({ id: 2, status: QuestStatus.InProgress }),
-      createQuest({ id: 3, status: QuestStatus.Completed }),
-      createQuest({ id: 4, status: QuestStatus.Pending }),
-    ]);
+	it("クエストを status ごとに分類する", () => {
+		const result = categorizeQuestsByStatus([
+			createQuest({ id: 1, status: QuestStatus.Active }),
+			createQuest({ id: 2, status: QuestStatus.InProgress }),
+			createQuest({ id: 3, status: QuestStatus.Completed }),
+			createQuest({ id: 4, status: QuestStatus.Pending }),
+		]);
 
-    expect(result.participating.map((quest) => quest.id)).toEqual([1, 2]);
-    expect(result.completed.map((quest) => quest.id)).toEqual([3]);
-    expect(result.applied.map((quest) => quest.id)).toEqual([4]);
-  });
+		expect(result.participating.map((quest) => quest.id)).toEqual([1, 2]);
+		expect(result.completed.map((quest) => quest.id)).toEqual([3]);
+		expect(result.applied.map((quest) => quest.id)).toEqual([4]);
+	});
 });

--- a/apps/frontend/src/__tests__/services/quest.test.ts
+++ b/apps/frontend/src/__tests__/services/quest.test.ts
@@ -1,7 +1,6 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
 import { questService } from "@/services/quest";
-import { QuestStatus, QuestType } from "@/types/quest";
-import type { Quest } from "@/types/quest";
+import { type Quest, QuestStatus, QuestType } from "@quest-board/types";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // httpClient をモック化
 vi.mock("@/services/httpClient", () => ({
@@ -112,10 +111,9 @@ describe("questService", () => {
 
 			await questService.getAllQuestsIncludingDeleted();
 
-			expect(authenticatedApiClient.get).toHaveBeenCalledWith(
-				"/quests",
-				{ includeDeleted: true },
-			);
+			expect(authenticatedApiClient.get).toHaveBeenCalledWith("/quests", {
+				includeDeleted: true,
+			});
 		});
 	});
 

--- a/apps/frontend/src/components/molecules/QuestCard.tsx
+++ b/apps/frontend/src/components/molecules/QuestCard.tsx
@@ -1,164 +1,146 @@
-import React from "react";
+import { getQuestRibbonStatus } from "@/constants/questPresentation";
+import type React from "react";
+import DifficultyBadge from "../atoms/DifficultyBadge";
 import StatusRibbon from "../atoms/StatusRibbon";
 import Tag from "../atoms/Tag";
-import DifficultyBadge from "../atoms/DifficultyBadge";
 import QuestTitle from "./QuestTitle";
-import { useRouter } from "next/navigation";
 
 interface Quest {
-  id: number;
-  title: string;
-  reward: number;
-  deadline?: string;
-  progress?: number;
-  difficulty: "初級" | "中級" | "上級";
-  status?: string;
-  category: string;
-  completedDate?: string;
-  appliedDate?: string;
+	id: number;
+	title: string;
+	reward: number;
+	deadline?: string;
+	progress?: number;
+	difficulty: "初級" | "中級" | "上級";
+	status?: string;
+	category: string;
+	completedDate?: string;
+	appliedDate?: string;
 }
 
 interface QuestCardProps {
-  quest: Quest;
-  /** 表示用のステータス（タブ側から上書き）。未指定ならquest.statusをマッピング */
-  status?: "participating" | "completed" | "applied";
-  /** 行動ボタンのクリック。未指定ならボタンは無効化/非表示 */
-  onActionClick?: (quest: Quest) => void;
+	quest: Quest;
+	/** 表示用のステータス（タブ側から上書き）。未指定ならquest.statusをマッピング */
+	status?: "participating" | "completed" | "applied";
+	/** 行動ボタンのクリック。未指定ならボタンは無効化/非表示 */
+	onActionClick?: (quest: Quest) => void;
 }
 
 // クエスト情報のカード
 const QuestCard: React.FC<QuestCardProps> = ({
-  quest,
-  status,
-  onActionClick,
+	quest,
+	status,
+	onActionClick,
 }) => {
-  const router = useRouter();
+	const formatCurrency = (amount?: number) => {
+		if (amount === undefined || amount === null) return "-";
+		const numAmount = Number(amount);
+		if (Number.isNaN(numAmount)) return "-";
+		return new Intl.NumberFormat("ja-JP", {
+			style: "currency",
+			currency: "JPY",
+			maximumFractionDigits: 0,
+		}).format(numAmount);
+	};
 
-  const handleCardClick = () => {
-    router.push(`/quests/${quest.id}`); // 詳細ページへ
-  };
+	return (
+		<div className="bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 border-2 border-amber-200 relative overflow-hidden">
+			{/* Status Ribbon */}
+			<StatusRibbon status={status ?? getQuestRibbonStatus(quest.status)} />
 
-  const formatCurrency = (amount?: number) => {
-    if (amount === undefined || amount === null) return "-";
-    const numAmount = Number(amount);
-    if (Number.isNaN(numAmount)) return "-";
-    return new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-      maximumFractionDigits: 0,
-    }).format(numAmount);
-  };
+			{/* Difficulty Badge */}
+			<div className="absolute top-4 left-4">
+				<DifficultyBadge difficulty={quest.difficulty} />
+			</div>
 
-  return (
-    <div
-      className="bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 border-2 border-amber-200 relative overflow-hidden"
-      onClick={handleCardClick}
-    >
-      {/* Status Ribbon */}
-      <StatusRibbon
-        status={((): "participating" | "completed" | "applied" => {
-          if (status) return status; // タブからの指定を優先
-          // クエストの元ステータスから表示用にマッピング
-          const raw = (quest.status || "").toLowerCase();
-          if (raw === "active" || raw === "in_progress") return "participating";
-          if (raw === "completed" || raw === "cleared") return "completed";
-          return "applied";
-        })()}
-      />
+			<div className="p-6 pt-8">
+				{/* Quest Title */}
+				<QuestTitle
+					title={quest.title}
+					description="クエストの詳細情報がここに表示されます"
+				/>
 
-      {/* Difficulty Badge */}
-      <div className="absolute top-4 left-4">
-        <DifficultyBadge difficulty={quest.difficulty} />
-      </div>
+				{/* Category Tag */}
+				<Tag>{quest.category}</Tag>
 
-      <div className="p-6 pt-8">
-        {/* Quest Title */}
-        <QuestTitle
-          title={quest.title}
-          description="クエストの詳細情報がここに表示されます"
-        />
+				{/* Quest Details */}
+				<div className="space-y-2 mb-4 text-sm text-slate-600">
+					<div className="flex items-center justify-between">
+						<span>難易度:</span>
+						<span className="font-semibold">{quest.difficulty}</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span>報酬:</span>
+						<div className="text-right">
+							<div className="font-semibold text-yellow-600">
+								{formatCurrency(quest.reward)}
+							</div>
+						</div>
+					</div>
+					{quest.deadline && (
+						<div className="flex items-center justify-between">
+							<span>期限:</span>
+							<span className="font-semibold text-xs">
+								{new Date(quest.deadline).toLocaleDateString("ja-JP")}
+							</span>
+						</div>
+					)}
+					{quest.progress !== undefined && (
+						<div className="space-y-2">
+							<div className="flex items-center justify-between">
+								<span>進捗:</span>
+								<span className="text-blue-400 text-sm">{quest.progress}%</span>
+							</div>
+							<div className="w-full bg-slate-300 rounded-full h-2">
+								<div
+									className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all duration-300"
+									style={{ width: `${quest.progress}%` }}
+								/>
+							</div>
+						</div>
+					)}
+					{quest.completedDate && (
+						<div className="flex items-center justify-between">
+							<span>完了日:</span>
+							<span className="font-semibold text-xs text-green-600">
+								{new Date(quest.completedDate).toLocaleDateString("ja-JP")}
+							</span>
+						</div>
+					)}
+					{quest.appliedDate && (
+						<div className="flex items-center justify-between">
+							<span>応募日:</span>
+							<span className="font-semibold text-xs text-orange-600">
+								{new Date(quest.appliedDate).toLocaleDateString("ja-JP")}
+							</span>
+						</div>
+					)}
+				</div>
 
-        {/* Category Tag */}
-        <Tag>{quest.category}</Tag>
-
-        {/* Quest Details */}
-        <div className="space-y-2 mb-4 text-sm text-slate-600">
-          <div className="flex items-center justify-between">
-            <span>難易度:</span>
-            <span className="font-semibold">{quest.difficulty}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>報酬:</span>
-            <div className="text-right">
-              <div className="font-semibold text-yellow-600">
-                {formatCurrency(quest.reward)}
-              </div>
-            </div>
-          </div>
-          {quest.deadline && (
-            <div className="flex items-center justify-between">
-              <span>期限:</span>
-              <span className="font-semibold text-xs">
-                {new Date(quest.deadline).toLocaleDateString("ja-JP")}
-              </span>
-            </div>
-          )}
-          {quest.progress !== undefined && (
-            <div className="space-y-2">
-              <div className="flex items-center justify-between">
-                <span>進捗:</span>
-                <span className="text-blue-400 text-sm">{quest.progress}%</span>
-              </div>
-              <div className="w-full bg-slate-300 rounded-full h-2">
-                <div
-                  className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all duration-300"
-                  style={{ width: `${quest.progress}%` }}
-                ></div>
-              </div>
-            </div>
-          )}
-          {quest.completedDate && (
-            <div className="flex items-center justify-between">
-              <span>完了日:</span>
-              <span className="font-semibold text-xs text-green-600">
-                {new Date(quest.completedDate).toLocaleDateString("ja-JP")}
-              </span>
-            </div>
-          )}
-          {quest.appliedDate && (
-            <div className="flex items-center justify-between">
-              <span>応募日:</span>
-              <span className="font-semibold text-xs text-orange-600">
-                {new Date(quest.appliedDate).toLocaleDateString("ja-JP")}
-              </span>
-            </div>
-          )}
-        </div>
-
-        {/* Action Button */}
-        <button
-          onClick={(e) => {
-            e.stopPropagation(); // カードクリックと分離
-            onActionClick?.(quest);
-          }}
-          className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${
-            (status || "participating") === "participating"
-              ? "bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:from-blue-700 hover:to-blue-800"
-              : (status || "participating") === "applied"
-              ? "bg-gradient-to-r from-orange-500 to-orange-600 text-white cursor-not-allowed opacity-75"
-              : "bg-gradient-to-r from-green-500 to-green-600 text-white cursor-not-allowed opacity-75"
-          }`}
-          disabled={
-            (status || "participating") !== "participating" || !onActionClick
-          }
-        >
-          {(status || "participating") === "participating" && "クエストを続行"}
-          {(status || "participating") === "applied" && "応募済み"}
-          {(status || "participating") === "completed" && "クエスト完了済み"}
-        </button>
-      </div>
-    </div>
-  );
+				{/* Action Button */}
+				<button
+					type="button"
+					onClick={() => {
+						onActionClick?.(quest);
+					}}
+					className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${
+						(status || "participating") === "participating"
+							? "bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:from-blue-700 hover:to-blue-800"
+							: (status || "participating") === "applied"
+								? "bg-gradient-to-r from-orange-500 to-orange-600 text-white cursor-not-allowed opacity-75"
+								: "bg-gradient-to-r from-green-500 to-green-600 text-white cursor-not-allowed opacity-75"
+					}`}
+					disabled={
+						(status || "participating") !== "participating" || !onActionClick
+					}
+				>
+					{(status || "participating") === "participating" && "クエストを続行"}
+					{(status || "participating") === "applied" && "応募済み"}
+					{(status || "participating") === "completed" && "クエスト完了済み"}
+				</button>
+			</div>
+		</div>
+	);
 };
 
 export default QuestCard;

--- a/apps/frontend/src/components/organisms/AdminDashboard.tsx
+++ b/apps/frontend/src/components/organisms/AdminDashboard.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import {
+	getQuestStatusBadgeClass,
+	getQuestStatusLabel,
+} from "@/constants/questPresentation";
 import { useAuth } from "@/hooks/useAuth";
 import type { Quest } from "@quest-board/types";
 import {
@@ -120,25 +124,6 @@ const AdminDashboard = () => {
 		),
 	};
 
-	const getStatusColor = (status: string): string => {
-		switch (status) {
-			case "pending":
-				return "bg-yellow-500";
-			case "active":
-				return "bg-blue-500";
-			case "completed":
-				return "bg-green-500";
-			case "draft":
-				return "bg-gray-500";
-			case "in_progress":
-				return "bg-purple-500";
-			case "inactive":
-				return "bg-gray-400";
-			default:
-				return "bg-gray-500";
-		}
-	};
-
 	const getPriorityColor = (priority: QuestPriority): string => {
 		switch (priority) {
 			case "critical":
@@ -151,25 +136,6 @@ const AdminDashboard = () => {
 				return "text-green-600";
 			default:
 				return "text-gray-600";
-		}
-	};
-
-	const getStatusText = (status: string): string => {
-		switch (status) {
-			case "pending":
-				return "承認待ち";
-			case "active":
-				return "公開中";
-			case "completed":
-				return "完了";
-			case "draft":
-				return "下書き";
-			case "in_progress":
-				return "進行中";
-			case "inactive":
-				return "停止中";
-			default:
-				return status;
 		}
 	};
 
@@ -361,11 +327,11 @@ const AdminDashboard = () => {
 					<div className="flex items-center gap-3">
 						<h3 className="font-semibold text-slate-800">{quest.title}</h3>
 						<span
-							className={`px-2 py-1 rounded-full text-xs text-white ${getStatusColor(
+							className={`px-2 py-1 rounded-full text-xs text-white ${getQuestStatusBadgeClass(
 								quest.status,
 							)}`}
 						>
-							{getStatusText(quest.status)}
+							{getQuestStatusLabel(quest.status)}
 						</span>
 						{quest.deleted_at && (
 							<span className="px-2 py-1 rounded-full text-xs text-white bg-red-500">
@@ -648,11 +614,11 @@ const AdminDashboard = () => {
 					<div className="text-sm">
 						<span className="font-medium text-slate-800">ステータス: </span>
 						<span
-							className={`px-2 py-1 rounded-full text-xs text-white ${getStatusColor(
+							className={`px-2 py-1 rounded-full text-xs text-white ${getQuestStatusBadgeClass(
 								quest.status,
 							)}`}
 						>
-							{getStatusText(quest.status)}
+							{getQuestStatusLabel(quest.status)}
 						</span>
 					</div>
 					<div className="text-sm">

--- a/apps/frontend/src/components/organisms/QuestHistory.tsx
+++ b/apps/frontend/src/components/organisms/QuestHistory.tsx
@@ -1,121 +1,114 @@
-import React, { useMemo, useState } from "react";
+import { getQuestRibbonStatus } from "@/constants/questPresentation";
+import { type Quest as FullQuest, QuestDifficulty } from "@quest-board/types";
+import { AlertCircle, CheckCircle, Clock, Sword } from "lucide-react";
+import type React from "react";
+import { useMemo, useState } from "react";
 import Button from "../atoms/Button";
-import { Sword, Clock, CheckCircle, AlertCircle } from "lucide-react";
 import QuestCard from "../molecules/QuestCard";
-import { QuestDifficulty, type Quest as FullQuest } from "@quest-board/types";
 
 // 表示用の簡易クエスト型（QuestCardが想定する形に合わせる）
 type DisplayQuest = {
-  id: number;
-  title: string;
-  reward: number;
-  deadline?: string;
-  progress?: number;
-  difficulty: "初級" | "中級" | "上級";
-  category: string;
-  completedDate?: string;
-  appliedDate?: string;
-  status?: string;
+	id: number;
+	title: string;
+	reward: number;
+	deadline?: string;
+	progress?: number;
+	difficulty: "初級" | "中級" | "上級";
+	category: string;
+	completedDate?: string;
+	appliedDate?: string;
+	status?: string;
 };
 
 type QuestData = {
-  participating: FullQuest[];
-  completed: FullQuest[];
-  applied: FullQuest[];
+	participating: FullQuest[];
+	completed: FullQuest[];
+	applied: FullQuest[];
 };
 
 type QuestHistoryProps = {
-  questData: QuestData;
+	questData: QuestData;
 };
 
 const getDisplayDifficulty = (
-  difficulty?: FullQuest["difficulty"]
+	difficulty?: FullQuest["difficulty"],
 ): DisplayQuest["difficulty"] => {
-  switch (difficulty) {
-    case QuestDifficulty.Intermediate:
-      return "中級";
-    case QuestDifficulty.Advanced:
-      return "上級";
-    case QuestDifficulty.Beginner:
-    default:
-      return "初級";
-  }
+	switch (difficulty) {
+		case QuestDifficulty.Intermediate:
+			return "中級";
+		case QuestDifficulty.Advanced:
+			return "上級";
+		default:
+			return "初級";
+	}
 };
 
 // タブ切り替え付きクエスト一覧
 const QuestHistory: React.FC<QuestHistoryProps> = ({ questData }) => {
-  const [activeTab, setActiveTab] = useState<keyof QuestData>("participating");
+	const [activeTab, setActiveTab] = useState<keyof QuestData>("participating");
 
-  const tabs = [
-    { key: "participating" as const, label: "募集中", icon: Clock },
-    { key: "completed" as const, label: "完了済み", icon: CheckCircle },
-    { key: "applied" as const, label: "応募中", icon: AlertCircle },
-  ];
+	const tabs = [
+		{ key: "participating" as const, label: "募集中", icon: Clock },
+		{ key: "completed" as const, label: "完了済み", icon: CheckCircle },
+		{ key: "applied" as const, label: "応募中", icon: AlertCircle },
+	];
 
-  const currentQuests = useMemo(
-    () => questData[activeTab] || [],
-    [questData, activeTab]
-  );
+	const currentQuests = useMemo(
+		() => questData[activeTab] || [],
+		[questData, activeTab],
+	);
 
-  return (
-    <div className="bg-gradient-to-br from-stone-50 to-amber-50 p-6 rounded-xl border-4 border-stone-300 shadow-xl">
-      <h3 className="text-xl font-bold text-amber-900 mb-6 flex items-center gap-2 font-serif">
-        <Sword className="w-6 h-6" />
-        クエスト履歴
-      </h3>
+	return (
+		<div className="bg-gradient-to-br from-stone-50 to-amber-50 p-6 rounded-xl border-4 border-stone-300 shadow-xl">
+			<h3 className="text-xl font-bold text-amber-900 mb-6 flex items-center gap-2 font-serif">
+				<Sword className="w-6 h-6" />
+				クエスト履歴
+			</h3>
 
-      <div className="flex flex-wrap gap-2 mb-6">
-        {tabs.map(({ key, label, icon: Icon }) => (
-          <Button
-            key={key}
-            active={activeTab === key}
-            onClick={() => setActiveTab(key)}
-            className="flex items-center gap-2"
-          >
-            <Icon className="w-4 h-4" />
-            {label}
-          </Button>
-        ))}
-      </div>
+			<div className="flex flex-wrap gap-2 mb-6">
+				{tabs.map(({ key, label, icon: Icon }) => (
+					<Button
+						key={key}
+						active={activeTab === key}
+						onClick={() => setActiveTab(key)}
+						className="flex items-center gap-2"
+					>
+						<Icon className="w-4 h-4" />
+						{label}
+					</Button>
+				))}
+			</div>
 
-      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {currentQuests.length > 0 ? (
-          currentQuests.map((quest) => {
-            const display: DisplayQuest = {
-              id: quest.id,
-              title: quest.title,
-              reward: Number(quest.rewards?.incentive_amount ?? 0),
-              deadline: quest.end_date,
-              difficulty: getDisplayDifficulty(quest.difficulty),
-              category: String(quest.type || ""),
-              status: String(quest.status || ""),
-            };
+			<div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+				{currentQuests.length > 0 ? (
+					currentQuests.map((quest) => {
+						const display: DisplayQuest = {
+							id: quest.id,
+							title: quest.title,
+							reward: Number(quest.rewards?.incentive_amount ?? 0),
+							deadline: quest.end_date,
+							difficulty: getDisplayDifficulty(quest.difficulty),
+							category: String(quest.type || ""),
+							status: String(quest.status || ""),
+						};
 
-            // クエスト一覧と同じマッピングロジックを使用（直接比較）
-            const mappedStatus = (
-              quest.status === "active"
-                ? "participating"
-                : quest.status === "completed"
-                ? "completed"
-                : "applied"
-            ) as "participating" | "completed" | "applied";
-            return (
-              <QuestCard
-                key={display.id}
-                quest={display}
-                status={mappedStatus}
-              />
-            );
-          })
-        ) : (
-          <div className="col-span-full text-center text-stone-500 py-8">
-            <Sword className="w-12 h-12 mx-auto mb-4 opacity-50" />
-            <p>該当するクエストがありません</p>
-          </div>
-        )}
-      </div>
-    </div>
-  );
+						return (
+							<QuestCard
+								key={display.id}
+								quest={display}
+								status={getQuestRibbonStatus(quest.status)}
+							/>
+						);
+					})
+				) : (
+					<div className="col-span-full text-center text-stone-500 py-8">
+						<Sword className="w-12 h-12 mx-auto mb-4 opacity-50" />
+						<p>該当するクエストがありません</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
 };
 
 export default QuestHistory;

--- a/apps/frontend/src/components/organisms/QuestJoinDialog.tsx
+++ b/apps/frontend/src/components/organisms/QuestJoinDialog.tsx
@@ -1,183 +1,161 @@
 "use client";
 
-import React from "react";
+import { authenticatedApiClient } from "@/services/httpClient";
 import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogContentText,
-  DialogActions,
-  Button,
-  Box,
+	Box,
+	Button,
+	Dialog,
+	DialogActions,
+	DialogContent,
+	DialogContentText,
+	DialogTitle,
 } from "@mui/material";
-import { getAuth } from "firebase/auth";
 import type { Quest } from "@quest-board/types";
+import type React from "react";
 
 interface QuestJoinDialogProps {
-  quest: Quest | null;
-  isOpen: boolean;
-  onClose: () => void;
+	quest: Quest | null;
+	isOpen: boolean;
+	onClose: () => void;
 }
 
 const QuestJoinDialog: React.FC<QuestJoinDialogProps> = ({
-  quest,
-  isOpen,
-  onClose,
+	quest,
+	isOpen,
+	onClose,
 }) => {
-  if (!quest) return null;
+	if (!quest) return null;
 
-  const currentParticipants = quest._count?.quest_participants || 0;
-  const maxParticipants = quest.maxParticipants || "-";
+	const currentParticipants = quest._count?.quest_participants || 0;
+	const maxParticipants = quest.maxParticipants || "-";
 
-  // -------------------------------
-  // クエスト参加API呼び出し
-  // -------------------------------
-  const handleJoin = async () => {
-    if (!quest) return;
+	// -------------------------------
+	// クエスト参加API呼び出し
+	// -------------------------------
+	const handleJoin = async () => {
+		if (!quest) return;
 
-    try {
-      const auth = getAuth();
-      const user = auth.currentUser;
-      const idToken = user ? await user.getIdToken() : "";
+		try {
+			const data = await authenticatedApiClient.post<
+				{
+					success?: boolean;
+					message?: string;
+				},
+				Record<string, never>
+			>(`/quests/${quest.id}/participants`, {});
 
-      if (!idToken) {
-        alert("ログイン状態を確認してください");
-        return;
-      }
+			if (data.success) {
+				alert("クエストに参加しました！");
+				onClose(); // ダイアログを閉じる
+				// 参加者数更新など必要なら state を更新
+			} else {
+				alert(data.message || "参加できませんでした");
+			}
+		} catch (err) {
+			console.error(err);
+			if (err instanceof Error && err.message === "User not authenticated") {
+				alert("ログイン状態を確認してください");
+				return;
+			}
+			alert("参加に失敗しました");
+		}
+	};
 
-      // 環境変数から API のベース URL を取得
-      const apiBaseUrl = process.env.NEXT_PUBLIC_API_BASE_URL;
-      if (!apiBaseUrl) {
-        console.error("NEXT_PUBLIC_API_BASE_URL が設定されていません");
-        alert("API の接続先が未設定です");
-        return;
-      }
+	return (
+		<Dialog
+			open={isOpen}
+			onClose={onClose}
+			fullWidth
+			maxWidth="sm"
+			PaperProps={{
+				sx: {
+					backgroundColor: "#fef3c7",
+					border: "3px solid #d1a054",
+					borderRadius: "16px",
+					p: 2,
+					fontFamily: "'Noto Sans JP', sans-serif",
+					color: "#374151",
+				},
+			}}
+		>
+			<DialogTitle
+				sx={{
+					fontSize: "1.5rem",
+					color: "#1e3a8a",
+					textAlign: "center",
+				}}
+			>
+				{quest.title}
+			</DialogTitle>
 
-      // fetch の URL を環境変数を使用して作成
-      const res = await fetch(`${apiBaseUrl}/api/quests/${quest.id}/participants`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${idToken}`,
-        },
-        credentials: "include",
-      });
+			<DialogContent>
+				<DialogContentText
+					sx={{
+						fontSize: "1rem",
+						lineHeight: 1.6,
+						mb: 2,
+					}}
+				>
+					{quest.description}
+				</DialogContentText>
 
-      if (!res.ok) {
-        const text = await res.text();
-        console.error("API error:", text);
-        alert("参加に失敗しました");
-        return;
-      }
+				<Box
+					sx={{
+						display: "flex",
+						justifyContent: "space-between",
+						fontSize: "0.875rem",
+						fontWeight: "bold",
+						mb: 2,
+						color: "#16a34a",
+					}}
+				>
+					<span>難易度: {quest.difficulty}</span>
+					<span>
+						参加者: {currentParticipants}/{maxParticipants} 名
+					</span>
+				</Box>
+			</DialogContent>
 
-      const data = await res.json();
+			<DialogActions sx={{ justifyContent: "center", gap: 2 }}>
+				<Button
+					onClick={onClose}
+					sx={{
+						backgroundColor: "#451a03",
+						color: "#fef3c7",
+						fontWeight: "bold",
+						borderRadius: "8px",
+						px: 3,
+						py: 1,
+						"&:hover": {
+							backgroundColor: "#6b3a0a",
+						},
+					}}
+				>
+					キャンセル
+				</Button>
 
-      if (data.success) {
-        alert("クエストに参加しました！");
-        onClose(); // ダイアログを閉じる
-        // 参加者数更新など必要なら state を更新
-      } else {
-        alert(data.message || "参加できませんでした");
-      }
-    } catch (err) {
-      console.error(err);
-      alert("参加に失敗しました");
-    }
-  };
-
-  return (
-    <Dialog
-      open={isOpen}
-      onClose={onClose}
-      fullWidth
-      maxWidth="sm"
-      PaperProps={{
-        sx: {
-          backgroundColor: "#fef3c7",
-          border: "3px solid #d1a054",
-          borderRadius: "16px",
-          p: 2,
-          fontFamily: "'Noto Sans JP', sans-serif",
-          color: "#374151",
-        },
-      }}
-    >
-      <DialogTitle
-        sx={{
-          fontSize: "1.5rem",
-          color: "#1e3a8a",
-          textAlign: "center",
-        }}
-      >
-        {quest.title}
-      </DialogTitle>
-
-      <DialogContent>
-        <DialogContentText
-          sx={{
-            fontSize: "1rem",
-            lineHeight: 1.6,
-            mb: 2,
-          }}
-        >
-          {quest.description}
-        </DialogContentText>
-
-        <Box
-          sx={{
-            display: "flex",
-            justifyContent: "space-between",
-            fontSize: "0.875rem",
-            fontWeight: "bold",
-            mb: 2,
-            color: "#16a34a",
-          }}
-        >
-          <span>難易度: {quest.difficulty}</span>
-          <span>参加者: {currentParticipants}/{maxParticipants} 名</span>
-        </Box>
-      </DialogContent>
-
-      <DialogActions sx={{ justifyContent: "center", gap: 2 }}>
-        <Button
-          onClick={onClose}
-          sx={{
-            backgroundColor: "#451a03",
-            color: "#fef3c7",
-            fontWeight: "bold",
-            borderRadius: "8px",
-            px: 3,
-            py: 1,
-            "&:hover": {
-              backgroundColor: "#6b3a0a",
-            },
-          }}
-        >
-          キャンセル
-        </Button>
-
-        <Button
-          onClick={handleJoin}
-          variant="contained"
-          sx={{
-            background: "linear-gradient(45deg, #1e3a8a, #3b82f6)",
-            color: "#fff",
-            fontWeight: "bold",
-            borderRadius: "8px",
-            px: 3,
-            py: 1,
-            boxShadow: "0 4px 6px rgba(0,0,0,0.3)",
-            "&:hover": {
-              background: "linear-gradient(45deg, #3b82f6, #1e3a8a)",
-              boxShadow: "0 6px 8px rgba(0,0,0,0.4)",
-            },
-          }}
-        >
-          参加する
-        </Button>
-      </DialogActions>
-    </Dialog>
-  );
+				<Button
+					onClick={handleJoin}
+					variant="contained"
+					sx={{
+						background: "linear-gradient(45deg, #1e3a8a, #3b82f6)",
+						color: "#fff",
+						fontWeight: "bold",
+						borderRadius: "8px",
+						px: 3,
+						py: 1,
+						boxShadow: "0 4px 6px rgba(0,0,0,0.3)",
+						"&:hover": {
+							background: "linear-gradient(45deg, #3b82f6, #1e3a8a)",
+							boxShadow: "0 6px 8px rgba(0,0,0,0.4)",
+						},
+					}}
+				>
+					参加する
+				</Button>
+			</DialogActions>
+		</Dialog>
+	);
 };
 
 export default QuestJoinDialog;

--- a/apps/frontend/src/components/organisms/QuestList.tsx
+++ b/apps/frontend/src/components/organisms/QuestList.tsx
@@ -1,456 +1,445 @@
 "use client";
 
-import React, { useEffect, useRef, useState } from "react";
-import {
-  Search,
-  Sword,
-  Book,
-  Wrench,
-  MessageSquare,
-  Eye,
-} from "lucide-react";
 import QuestJoinDialog from "@/components/organisms/QuestJoinDialog";
-import { Quest, QuestDifficulty, QuestType } from "@quest-board/types";
+import QuestListCard, {
+	type CompletedQuestButtonAction,
+} from "@/components/organisms/QuestListCard";
+import {
+	filterQuests,
+	getSuggestedQuests,
+} from "@/components/organisms/questListFilters";
+import {
+	HIDDEN_QUEST_STATUSES,
+	getQuestDifficultyBadgeClass,
+	getQuestTypeIconKind,
+} from "@/constants/questPresentation";
+import { useAuth } from "@/hooks/useAuth";
 import { questService } from "@/services/quest";
 import { reviewService } from "@/services/review";
 import { userService } from "@/services/user";
-import { useAuth } from "@/hooks/useAuth";
+import type { Quest } from "@quest-board/types";
+import { Book, Eye, MessageSquare, Search, Sword, Wrench } from "lucide-react";
 import { useRouter } from "next/navigation";
-import QuestListCard, {
-  type CompletedQuestButtonAction,
-} from "@/components/organisms/QuestListCard";
-import {
-  filterQuests,
-  getSuggestedQuests,
-} from "@/components/organisms/questListFilters";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
 
-// 一般ユーザーに非表示にするクエストステータス
-const HIDDEN_QUEST_STATUSES: string[] = ["draft", "pending", "inactive"];
+const QUEST_SKELETON_KEYS = Array.from(
+	{ length: 6 },
+	(_, index) => `skeleton-card-${index + 1}`,
+);
 
 const QuestListSkeleton = () => (
-  <div className="w-full">
-    <section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
-      <div className="mb-8 space-y-4 animate-pulse">
-        <div className="flex flex-col sm:flex-row gap-4">
-          <div className="h-12 flex-1 rounded-lg bg-slate-700/80" />
-          <div className="h-12 w-full rounded-lg bg-slate-700/70 sm:w-56" />
-        </div>
-      </div>
+	<div className="w-full">
+		<section className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
+			<div className="mb-8 space-y-4 animate-pulse">
+				<div className="flex flex-col sm:flex-row gap-4">
+					<div className="h-12 flex-1 rounded-lg bg-slate-700/80" />
+					<div className="h-12 w-full rounded-lg bg-slate-700/70 sm:w-56" />
+				</div>
+			</div>
 
-      <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
-        {Array.from({ length: 6 }).map((_, index) => (
-          <div
-            key={`skeleton-card-${index}`}
-            className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-800/70 shadow-lg"
-          >
-            <div className="space-y-4 p-6">
-              <div className="flex items-center justify-between">
-                <div className="h-8 w-8 rounded-full bg-slate-700" />
-                <div className="h-6 w-24 rounded-full bg-slate-700" />
-              </div>
-              <div className="space-y-2">
-                <div className="h-6 w-3/4 rounded bg-slate-600" />
-                <div className="h-4 w-full rounded bg-slate-700" />
-                <div className="h-4 w-5/6 rounded bg-slate-700" />
-              </div>
-              <div className="flex flex-wrap gap-2">
-                <div className="h-6 w-16 rounded-full bg-slate-700" />
-                <div className="h-6 w-20 rounded-full bg-slate-700" />
-                <div className="h-6 w-14 rounded-full bg-slate-700" />
-              </div>
-              <div className="grid grid-cols-2 gap-3 pt-3">
-                <div className="h-16 rounded-2xl bg-slate-700/80" />
-                <div className="h-16 rounded-2xl bg-slate-700/80" />
-              </div>
-              <div className="h-11 rounded-2xl bg-slate-600/80" />
-            </div>
-          </div>
-        ))}
-      </div>
-    </section>
-  </div>
+			<div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+				{QUEST_SKELETON_KEYS.map((key) => (
+					<div
+						key={key}
+						className="overflow-hidden rounded-3xl border border-slate-700 bg-slate-800/70 shadow-lg"
+					>
+						<div className="space-y-4 p-6">
+							<div className="flex items-center justify-between">
+								<div className="h-8 w-8 rounded-full bg-slate-700" />
+								<div className="h-6 w-24 rounded-full bg-slate-700" />
+							</div>
+							<div className="space-y-2">
+								<div className="h-6 w-3/4 rounded bg-slate-600" />
+								<div className="h-4 w-full rounded bg-slate-700" />
+								<div className="h-4 w-5/6 rounded bg-slate-700" />
+							</div>
+							<div className="flex flex-wrap gap-2">
+								<div className="h-6 w-16 rounded-full bg-slate-700" />
+								<div className="h-6 w-20 rounded-full bg-slate-700" />
+								<div className="h-6 w-14 rounded-full bg-slate-700" />
+							</div>
+							<div className="grid grid-cols-2 gap-3 pt-3">
+								<div className="h-16 rounded-2xl bg-slate-700/80" />
+								<div className="h-16 rounded-2xl bg-slate-700/80" />
+							</div>
+							<div className="h-11 rounded-2xl bg-slate-600/80" />
+						</div>
+					</div>
+				))}
+			</div>
+		</section>
+	</div>
 );
 
 const QuestList: React.FC = () => {
-  const [quests, setQuests] = useState<Quest[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [selectedFilter, setSelectedFilter] = useState("all");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
-  const [showSuggestions, setShowSuggestions] = useState(false);
-  const [startDateFilter, setStartDateFilter] = useState("");
-  const [endDateFilter, setEndDateFilter] = useState("");
-  const [isDialogOpen, setIsDialogOpen] = useState(false);
-  const [selectedQuest, setSelectedQuest] = useState<Quest | null>(null);
-  const [buttonActions, setButtonActions] = useState<
-    Map<number, CompletedQuestButtonAction>
-  >(new Map());
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
-  const searchContainerRef = useRef<HTMLDivElement | null>(null);
-  const { user, isAuthenticated } = useAuth();
-  const router = useRouter();
+	const [quests, setQuests] = useState<Quest[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [selectedFilter, setSelectedFilter] = useState("all");
+	const [searchQuery, setSearchQuery] = useState("");
+	const [debouncedSearchQuery, setDebouncedSearchQuery] = useState("");
+	const [showSuggestions, setShowSuggestions] = useState(false);
+	const [startDateFilter, setStartDateFilter] = useState("");
+	const [endDateFilter, setEndDateFilter] = useState("");
+	const [isDialogOpen, setIsDialogOpen] = useState(false);
+	const [selectedQuest, setSelectedQuest] = useState<Quest | null>(null);
+	const [buttonActions, setButtonActions] = useState<
+		Map<number, CompletedQuestButtonAction>
+	>(new Map());
+	const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+	const searchContainerRef = useRef<HTMLDivElement | null>(null);
+	const { user, isAuthenticated } = useAuth();
+	const router = useRouter();
 
-  useEffect(() => {
-    const fetchQuests = async () => {
-      try {
-        const data = await questService.getAllQuests();
-        setQuests(data);
-      } catch (err) {
-        console.error(err);
-        setQuests([]);
-      } finally {
-        setLoading(false);
-      }
-    };
-    fetchQuests();
-  }, []);
+	useEffect(() => {
+		const fetchQuests = async () => {
+			try {
+				const data = await questService.getAllQuests();
+				setQuests(data);
+			} catch (err) {
+				console.error(err);
+				setQuests([]);
+			} finally {
+				setLoading(false);
+			}
+		};
+		fetchQuests();
+	}, []);
 
-  useEffect(() => {
-    const timerId = window.setTimeout(() => {
-      setDebouncedSearchQuery(searchQuery.trim());
-    }, 200);
+	useEffect(() => {
+		const timerId = window.setTimeout(() => {
+			setDebouncedSearchQuery(searchQuery.trim());
+		}, 200);
 
-    return () => window.clearTimeout(timerId);
-  }, [searchQuery]);
+		return () => window.clearTimeout(timerId);
+	}, [searchQuery]);
 
-  // ユーザーIDを動的に取得
-  useEffect(() => {
-    const fetchUserId = async () => {
-      if (!user || !isAuthenticated) {
-        setCurrentUserId(null);
-        return;
-      }
+	// ユーザーIDを動的に取得
+	useEffect(() => {
+		const fetchUserId = async () => {
+			if (!user || !isAuthenticated) {
+				setCurrentUserId(null);
+				return;
+			}
 
-      try {
-        const userData = await userService.getCurrentUser();
-        setCurrentUserId(userData.id);
-      } catch (error) {
-        console.error("QuestList: ユーザーID取得エラー:", error);
-        setCurrentUserId(null);
-      }
-    };
+			try {
+				const userData = await userService.getCurrentUser();
+				setCurrentUserId(userData.id);
+			} catch (error) {
+				console.error("QuestList: ユーザーID取得エラー:", error);
+				setCurrentUserId(null);
+			}
+		};
 
-    fetchUserId();
-  }, [user, isAuthenticated]);
+		fetchUserId();
+	}, [user, isAuthenticated]);
 
-  // クエストデータが取得されたら、各クエストのボタンアクションを決定
-  useEffect(() => {
-    const updateButtonActions = async () => {
-      if (quests.length === 0 || !currentUserId) return;
+	// クエストデータが取得されたら、各クエストのボタンアクションを決定
+	useEffect(() => {
+		const updateButtonActions = async () => {
+			if (quests.length === 0 || !currentUserId) return;
 
-      const newButtonActions = new Map<number, CompletedQuestButtonAction>();
-      for (const quest of quests) {
-        if (quest.status === "completed") {
-          const action = await getCompletedQuestButtonAction(quest);
-          newButtonActions.set(quest.id, action);
-        }
-      }
-      setButtonActions(newButtonActions);
-    };
+			const newButtonActions = new Map<number, CompletedQuestButtonAction>();
+			for (const quest of quests) {
+				if (quest.status === "completed") {
+					const action = await getCompletedQuestButtonAction(quest);
+					newButtonActions.set(quest.id, action);
+				}
+			}
+			setButtonActions(newButtonActions);
+		};
 
-    updateButtonActions();
-  }, [quests, user, isAuthenticated, currentUserId]);
+		updateButtonActions();
+	}, [quests, currentUserId]);
 
-  const getIconComponent = (questType: string) => {
-    switch (questType) {
-      case QuestType.Development:
-        return <Wrench className="w-6 h-6" />;
-      case QuestType.Learning:
-        return <Book className="w-6 h-6" />;
-      case QuestType.Challenge:
-      case QuestType.Planning:
-      case QuestType.Maintenance:
-      case QuestType.Design:
-        return <Sword className="w-6 h-6" />;
-      default:
-        return <Sword className="w-6 h-6" />;
-    }
-  };
+	const getIconComponent = (questType: string) => {
+		const iconKind = getQuestTypeIconKind(questType);
+		if (iconKind === "wrench") {
+			return <Wrench className="w-6 h-6" />;
+		}
+		if (iconKind === "book") {
+			return <Book className="w-6 h-6" />;
+		}
+		return <Sword className="w-6 h-6" />;
+	};
 
-  const getDifficultyColor = (difficulty?: QuestDifficulty) => {
-    switch (difficulty) {
-      case QuestDifficulty.Beginner:
-        return "bg-green-500";
-      case QuestDifficulty.Intermediate:
-        return "bg-yellow-500";
-      case QuestDifficulty.Advanced:
-        return "bg-red-500";
-      default:
-        return "bg-gray-500";
-    }
-  };
+	const formatDate = (dateString: string) =>
+		new Date(dateString).toLocaleDateString("ja-JP", {
+			year: "numeric",
+			month: "short",
+			day: "numeric",
+		});
 
-  const formatDate = (dateString: string) =>
-    new Date(dateString).toLocaleDateString("ja-JP", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+	const formatCurrency = (amount?: string | number) => {
+		if (!amount) return "-";
+		const numAmount =
+			typeof amount === "string" ? Number.parseFloat(amount) : amount;
+		if (Number.isNaN(numAmount)) return "-";
+		return new Intl.NumberFormat("ja-JP", {
+			style: "currency",
+			currency: "JPY",
+			maximumFractionDigits: 0,
+		}).format(numAmount);
+	};
 
-  const formatCurrency = (amount?: string | number) => {
-    if (!amount) return "-";
-    const numAmount = typeof amount === "string" ? parseFloat(amount) : amount;
-    if (isNaN(numAmount)) return "-";
-    return new Intl.NumberFormat("ja-JP", {
-      style: "currency",
-      currency: "JPY",
-      maximumFractionDigits: 0,
-    }).format(numAmount);
-  };
+	// ユーザーがクエストに参加しているかどうかを判定
+	const isUserParticipant = (quest: Quest): boolean => {
+		if (!user || !isAuthenticated || !currentUserId) return false;
 
-  // ユーザーがクエストに参加しているかどうかを判定
-  const isUserParticipant = (quest: Quest): boolean => {
-    if (!user || !isAuthenticated || !currentUserId) return false;
+		const isParticipant =
+			quest.quest_participants?.some((participant) => {
+				return participant.user.id === currentUserId;
+			}) || false;
 
-    const isParticipant =
-      quest.quest_participants?.some((participant) => {
-        return participant.user.id === currentUserId;
-      }) || false;
+		return isParticipant;
+	};
 
-    return isParticipant;
-  };
+	// ユーザーがレビューを投稿済みかどうかを判定
+	const hasUserSubmittedReview = async (quest: Quest): Promise<boolean> => {
+		if (!user || !isAuthenticated || !currentUserId) return false;
 
-  // ユーザーがレビューを投稿済みかどうかを判定
-  const hasUserSubmittedReview = async (quest: Quest): Promise<boolean> => {
-    if (!user || !isAuthenticated || !currentUserId) return false;
+		const participant = quest.quest_participants?.find((p) => {
+			return p.user.id === currentUserId;
+		});
 
-    const participant = quest.quest_participants?.find((p) => {
-      return p.user.id === currentUserId;
-    });
+		if (!participant) return false;
 
-    if (!participant) return false;
+		// 実際のAPIを呼び出してレビュー投稿状況を確認
+		try {
+			const response = await reviewService.checkUserReviewExists(
+				currentUserId.toString(),
+				quest.id.toString(),
+			);
+			return response.exists;
+		} catch (error) {
+			console.error("レビュー投稿状況確認エラー:", error);
+			return false;
+		}
+	};
 
-    // 実際のAPIを呼び出してレビュー投稿状況を確認
-    try {
-      const response = await reviewService.checkUserReviewExists(
-        currentUserId.toString(),
-        quest.id.toString()
-      );
-      return response.exists;
-    } catch (error) {
-      console.error("レビュー投稿状況確認エラー:", error);
-      return false;
-    }
-  };
+	// 完了したクエストのボタンアクションを決定
+	const getCompletedQuestButtonAction = async (
+		quest: Quest,
+	): Promise<CompletedQuestButtonAction> => {
+		if (!isAuthenticated) {
+			return {
+				text: "レビューを見る",
+				action: () => router.push(`/quests/${quest.id}`),
+				icon: Eye,
+				className:
+					"bg-gradient-to-r from-gray-500 to-gray-600 text-white hover:from-gray-600 hover:to-gray-700",
+			};
+		}
 
-  // 完了したクエストのボタンアクションを決定
-  const getCompletedQuestButtonAction = async (
-    quest: Quest
-  ): Promise<CompletedQuestButtonAction> => {
-    if (!isAuthenticated) {
-      return {
-        text: "レビューを見る",
-        action: () => router.push(`/quests/${quest.id}`),
-        icon: Eye,
-        className:
-          "bg-gradient-to-r from-gray-500 to-gray-600 text-white hover:from-gray-600 hover:to-gray-700",
-      };
-    }
+		const isParticipant = isUserParticipant(quest);
+		const hasSubmittedReview = await hasUserSubmittedReview(quest);
 
-    const isParticipant = isUserParticipant(quest);
-    const hasSubmittedReview = await hasUserSubmittedReview(quest);
+		if (isParticipant && !hasSubmittedReview) {
+			return {
+				text: "レビューを投稿する",
+				action: () => router.push(`/quests/${quest.id}?action=review`),
+				icon: MessageSquare,
+				className:
+					"bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700",
+			};
+		}
 
-    if (isParticipant && !hasSubmittedReview) {
-      return {
-        text: "レビューを投稿する",
-        action: () => router.push(`/quests/${quest.id}?action=review`),
-        icon: MessageSquare,
-        className:
-          "bg-gradient-to-r from-green-500 to-green-600 text-white hover:from-green-600 hover:to-green-700",
-      };
-    } else {
-      return {
-        text: "レビューを見る",
-        action: () => router.push(`/quests/${quest.id}`),
-        icon: Eye,
-        className:
-          "bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700",
-      };
-    }
-  };
+		return {
+			text: "レビューを見る",
+			action: () => router.push(`/quests/${quest.id}`),
+			icon: Eye,
+			className:
+				"bg-gradient-to-r from-blue-500 to-blue-600 text-white hover:from-blue-600 hover:to-blue-700",
+		};
+	};
 
-  const handleJoinQuest = (quest: Quest) => {
-    setSelectedQuest(quest);
-    setIsDialogOpen(true);
-  };
+	const handleJoinQuest = (quest: Quest) => {
+		setSelectedQuest(quest);
+		setIsDialogOpen(true);
+	};
 
-  const normalizedSearchQuery = debouncedSearchQuery.toLowerCase();
-  const filterParams = {
-    selectedFilter,
-    normalizedSearchQuery,
-    startDateFilter,
-    endDateFilter,
-    hiddenStatuses: HIDDEN_QUEST_STATUSES,
-  };
-  const filteredQuests = filterQuests(quests, filterParams);
-  const suggestedQuests = getSuggestedQuests(quests, filterParams);
+	const normalizedSearchQuery = debouncedSearchQuery.toLowerCase();
+	const filterParams = {
+		selectedFilter,
+		normalizedSearchQuery,
+		startDateFilter,
+		endDateFilter,
+		hiddenStatuses: HIDDEN_QUEST_STATUSES,
+	};
+	const filteredQuests = filterQuests(quests, filterParams);
+	const suggestedQuests = getSuggestedQuests(quests, filterParams);
 
-  if (loading) {
-    return <QuestListSkeleton />;
-  }
+	if (loading) {
+		return <QuestListSkeleton />;
+	}
 
-  return (
-    <div className="w-full">
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
-        {/* Search and Filter */}
-        <div className="mb-8 space-y-4">
-          <div className="flex flex-col gap-4">
-            <div className="flex flex-col gap-4 sm:flex-row">
-              <div
-                ref={searchContainerRef}
-                className="relative flex-1"
-                onBlur={(event) => {
-                  const nextTarget = event.relatedTarget as Node | null;
-                  if (nextTarget && searchContainerRef.current?.contains(nextTarget)) {
-                    return;
-                  }
+	return (
+		<div className="w-full">
+			<main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 min-h-screen flex flex-col">
+				{/* Search and Filter */}
+				<div className="mb-8 space-y-4">
+					<div className="flex flex-col gap-4">
+						<div className="flex flex-col gap-4 sm:flex-row">
+							<div
+								ref={searchContainerRef}
+								className="relative flex-1"
+								onBlur={(event) => {
+									const nextTarget = event.relatedTarget as Node | null;
+									if (
+										nextTarget &&
+										searchContainerRef.current?.contains(nextTarget)
+									) {
+										return;
+									}
 
-                  setShowSuggestions(false);
-                }}
-              >
-                <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
-                <input
-                  type="text"
-                  placeholder="クエストを検索..."
-                  value={searchQuery}
-                  onFocus={() => setShowSuggestions(true)}
-                  onChange={(e) => setSearchQuery(e.target.value)}
-                  className="w-full pl-10 pr-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
-                />
+									setShowSuggestions(false);
+								}}
+							>
+								<Search className="absolute left-3 top-1/2 transform -translate-y-1/2 w-5 h-5 text-gray-400" />
+								<input
+									type="text"
+									placeholder="クエストを検索..."
+									value={searchQuery}
+									onFocus={() => setShowSuggestions(true)}
+									onChange={(e) => setSearchQuery(e.target.value)}
+									className="w-full pl-10 pr-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
+								/>
 
-                {showSuggestions && normalizedSearchQuery.length > 0 && (
-                  <div className="absolute z-20 mt-2 w-full overflow-hidden rounded-xl border border-slate-600 bg-slate-800 shadow-xl">
-                    {suggestedQuests.length > 0 ? (
-                      <ul className="divide-y divide-slate-700">
-                        {suggestedQuests.map((quest) => (
-                          <li key={quest.id}>
-                            <button
-                              type="button"
-                              className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition hover:bg-slate-700/80"
-                              onMouseDown={(event) => event.preventDefault()}
-                              onClick={() => {
-                                setSearchQuery(quest.title);
-                                setDebouncedSearchQuery(quest.title);
-                                setShowSuggestions(false);
-                              }}
-                            >
-                              <div>
-                                <p className="font-medium text-white">{quest.title}</p>
-                                <p className="mt-1 text-xs text-slate-300">
-                                  開始日: {formatDate(quest.start_date)}
-                                </p>
-                              </div>
-                              <span className="rounded-full bg-slate-700 px-2 py-1 text-xs text-slate-200">
-                                {quest.type}
-                              </span>
-                            </button>
-                          </li>
-                        ))}
-                      </ul>
-                    ) : (
-                      <div className="px-4 py-3 text-sm text-slate-300">
-                        タイトル一致する候補はありません
-                      </div>
-                    )}
-                  </div>
-                )}
-              </div>
+								{showSuggestions && normalizedSearchQuery.length > 0 && (
+									<div className="absolute z-20 mt-2 w-full overflow-hidden rounded-xl border border-slate-600 bg-slate-800 shadow-xl">
+										{suggestedQuests.length > 0 ? (
+											<ul className="divide-y divide-slate-700">
+												{suggestedQuests.map((quest) => (
+													<li key={quest.id}>
+														<button
+															type="button"
+															className="flex w-full items-start justify-between gap-3 px-4 py-3 text-left transition hover:bg-slate-700/80"
+															onMouseDown={(event) => event.preventDefault()}
+															onClick={() => {
+																setSearchQuery(quest.title);
+																setDebouncedSearchQuery(quest.title);
+																setShowSuggestions(false);
+															}}
+														>
+															<div>
+																<p className="font-medium text-white">
+																	{quest.title}
+																</p>
+																<p className="mt-1 text-xs text-slate-300">
+																	開始日: {formatDate(quest.start_date)}
+																</p>
+															</div>
+															<span className="rounded-full bg-slate-700 px-2 py-1 text-xs text-slate-200">
+																{quest.type}
+															</span>
+														</button>
+													</li>
+												))}
+											</ul>
+										) : (
+											<div className="px-4 py-3 text-sm text-slate-300">
+												タイトル一致する候補はありません
+											</div>
+										)}
+									</div>
+								)}
+							</div>
 
-              <select
-                value={selectedFilter}
-                onChange={(e) => setSelectedFilter(e.target.value)}
-                className="px-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
-              >
-                <option value="all">全てのクエスト</option>
-                <option value="active">募集中</option>
-                <option value="in_progress">進行中</option>
-                <option value="inactive">停止中</option>
-                <option value="completed">完了済み</option>
-              </select>
-            </div>
+							<select
+								value={selectedFilter}
+								onChange={(e) => setSelectedFilter(e.target.value)}
+								className="px-4 py-3 bg-slate-700 border border-slate-600 rounded-lg text-white focus:outline-none focus:ring-2 focus:ring-yellow-400 focus:border-transparent"
+							>
+								<option value="all">全てのクエスト</option>
+								<option value="active">募集中</option>
+								<option value="in_progress">進行中</option>
+								<option value="inactive">停止中</option>
+								<option value="completed">完了済み</option>
+							</select>
+						</div>
 
-            <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-              <label className="space-y-2">
-                <span className="text-sm font-medium text-slate-200">
-                  公開開始日 From
-                </span>
-                <input
-                  type="date"
-                  value={startDateFilter}
-                  onChange={(e) => setStartDateFilter(e.target.value)}
-                  className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
-                />
-              </label>
+						<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+							<label className="space-y-2">
+								<span className="text-sm font-medium text-slate-200">
+									公開開始日 From
+								</span>
+								<input
+									type="date"
+									value={startDateFilter}
+									onChange={(e) => setStartDateFilter(e.target.value)}
+									className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
+								/>
+							</label>
 
-              <label className="space-y-2">
-                <span className="text-sm font-medium text-slate-200">
-                  公開開始日 To
-                </span>
-                <input
-                  type="date"
-                  value={endDateFilter}
-                  min={startDateFilter || undefined}
-                  onChange={(e) => setEndDateFilter(e.target.value)}
-                  className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
-                />
-              </label>
+							<label className="space-y-2">
+								<span className="text-sm font-medium text-slate-200">
+									公開開始日 To
+								</span>
+								<input
+									type="date"
+									value={endDateFilter}
+									min={startDateFilter || undefined}
+									onChange={(e) => setEndDateFilter(e.target.value)}
+									className="w-full rounded-lg border border-slate-600 bg-slate-700 px-4 py-3 text-white focus:outline-none focus:ring-2 focus:ring-yellow-400"
+								/>
+							</label>
 
-              <div className="flex items-end sm:col-span-2 xl:justify-end">
-                <button
-                  type="button"
-                  className="w-full rounded-lg border border-slate-500 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-yellow-400 hover:text-yellow-300 xl:w-auto"
-                  onClick={() => {
-                    setSearchQuery("");
-                    setDebouncedSearchQuery("");
-                    setSelectedFilter("all");
-                    setStartDateFilter("");
-                    setEndDateFilter("");
-                    setShowSuggestions(false);
-                  }}
-                >
-                  フィルタをリセット
-                </button>
-              </div>
-            </div>
-          </div>
-        </div>
+							<div className="flex items-end sm:col-span-2 xl:justify-end">
+								<button
+									type="button"
+									className="w-full rounded-lg border border-slate-500 px-4 py-3 text-sm font-medium text-slate-200 transition hover:border-yellow-400 hover:text-yellow-300 xl:w-auto"
+									onClick={() => {
+										setSearchQuery("");
+										setDebouncedSearchQuery("");
+										setSelectedFilter("all");
+										setStartDateFilter("");
+										setEndDateFilter("");
+										setShowSuggestions(false);
+									}}
+								>
+									フィルタをリセット
+								</button>
+							</div>
+						</div>
+					</div>
+				</div>
 
-        {/* Quest Grid */}
-        <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
-          {filteredQuests.map((quest) => (
-            <QuestListCard
-              key={quest.id}
-              quest={quest}
-              difficultyColor={getDifficultyColor(quest.difficulty)}
-              icon={getIconComponent(quest.type)}
-              formatCurrency={formatCurrency}
-              formatDate={formatDate}
-              onJoin={handleJoinQuest}
-              completedButtonAction={buttonActions.get(quest.id)}
-            />
-          ))}
-        </div>
+				{/* Quest Grid */}
+				<div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-8">
+					{filteredQuests.map((quest) => (
+						<QuestListCard
+							key={quest.id}
+							quest={quest}
+							difficultyColor={getQuestDifficultyBadgeClass(quest.difficulty)}
+							icon={getIconComponent(quest.type)}
+							formatCurrency={formatCurrency}
+							formatDate={formatDate}
+							onJoin={handleJoinQuest}
+							completedButtonAction={buttonActions.get(quest.id)}
+						/>
+					))}
+				</div>
 
-        {filteredQuests.length === 0 && (
-          <div className="text-center py-12">
-            <div className="w-24 h-24 bg-slate-700 rounded-full flex items-center justify-center mx-auto mb-4">
-              <Search className="w-12 h-12 text-gray-400" />
-            </div>
-            <h3 className="text-xl font-semibold text-gray-300 mb-2">
-              クエストが見つかりません
-            </h3>
-            <p className="text-gray-400">検索条件を変更してお試しください</p>
-          </div>
-        )}
+				{filteredQuests.length === 0 && (
+					<div className="text-center py-12">
+						<div className="w-24 h-24 bg-slate-700 rounded-full flex items-center justify-center mx-auto mb-4">
+							<Search className="w-12 h-12 text-gray-400" />
+						</div>
+						<h3 className="text-xl font-semibold text-gray-300 mb-2">
+							クエストが見つかりません
+						</h3>
+						<p className="text-gray-400">検索条件を変更してお試しください</p>
+					</div>
+				)}
 
-        <QuestJoinDialog
-          quest={selectedQuest}
-          isOpen={isDialogOpen}
-          onClose={() => setIsDialogOpen(false)}
-        />
-      </main>
-    </div>
-  );
+				<QuestJoinDialog
+					quest={selectedQuest}
+					isOpen={isDialogOpen}
+					onClose={() => setIsDialogOpen(false)}
+				/>
+			</main>
+		</div>
+	);
 };
 
 export default QuestList;

--- a/apps/frontend/src/components/organisms/QuestListCard.tsx
+++ b/apps/frontend/src/components/organisms/QuestListCard.tsx
@@ -1,200 +1,201 @@
 "use client";
 
-import React from "react";
+import StatusRibbon from "@/components/atoms/StatusRibbon";
+import { getQuestRibbonStatus } from "@/constants/questPresentation";
+import type { Quest } from "@quest-board/types";
 import { Eye, Search } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import StatusRibbon from "@/components/atoms/StatusRibbon";
-import type { Quest } from "@quest-board/types";
+import type React from "react";
 
 export type CompletedQuestButtonAction = {
-  text: string;
-  action: () => void;
-  icon: LucideIcon;
-  className: string;
+	text: string;
+	action: () => void;
+	icon: LucideIcon;
+	className: string;
 };
 
 type QuestListCardProps = {
-  quest: Quest;
-  difficultyColor: string;
-  icon: React.ReactNode;
-  formatCurrency: (amount?: string | number) => string;
-  formatDate: (dateString: string) => string;
-  onJoin: (quest: Quest) => void;
-  completedButtonAction?: CompletedQuestButtonAction;
+	quest: Quest;
+	difficultyColor: string;
+	icon: React.ReactNode;
+	formatCurrency: (amount?: string | number) => string;
+	formatDate: (dateString: string) => string;
+	onJoin: (quest: Quest) => void;
+	completedButtonAction?: CompletedQuestButtonAction;
 };
 
 const QuestListCard: React.FC<QuestListCardProps> = ({
-  quest,
-  difficultyColor,
-  icon,
-  formatCurrency,
-  formatDate,
-  onJoin,
-  completedButtonAction,
+	quest,
+	difficultyColor,
+	icon,
+	formatCurrency,
+	formatDate,
+	onJoin,
+	completedButtonAction,
 }) => {
-  const participantCount = quest._count?.quest_participants ?? 0;
-  const CompletedIcon = completedButtonAction?.icon;
-  const progressPercent =
-    quest.maxParticipants > 0
-      ? Math.round((participantCount / quest.maxParticipants) * 100)
-      : 0;
+	const participantCount = quest._count?.quest_participants ?? 0;
+	const CompletedIcon = completedButtonAction?.icon;
+	const progressPercent =
+		quest.maxParticipants > 0
+			? Math.round((participantCount / quest.maxParticipants) * 100)
+			: 0;
 
-  return (
-    <div className="bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 border-2 border-amber-200 relative overflow-hidden">
-      <StatusRibbon
-        status={
-          quest.status === "active"
-            ? "participating"
-            : quest.status === "completed"
-            ? "completed"
-            : "applied"
-        }
-      />
+	return (
+		<div className="bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg hover:shadow-xl transition-all duration-300 hover:scale-105 border-2 border-amber-200 relative overflow-hidden">
+			<StatusRibbon status={getQuestRibbonStatus(quest.status)} />
 
-      <div className="absolute top-4 left-4">
-        <div className={`w-3 h-3 rounded-full ${difficultyColor}`}></div>
-      </div>
+			<div className="absolute top-4 left-4">
+				<div className={`w-3 h-3 rounded-full ${difficultyColor}`} />
+			</div>
 
-      <div className="p-6 pt-8">
-        <div className="flex items-start space-x-3 mb-4">
-          <div className="flex-shrink-0 w-12 h-12 bg-slate-700 rounded-lg flex items-center justify-center text-yellow-400">
-            {icon}
-          </div>
-          <div className="flex-1">
-            <h3 className="text-lg font-bold text-slate-800 mb-1">
-              {quest.title}
-            </h3>
-            <p className="text-sm text-slate-600 line-clamp-3">
-              {quest.description}
-            </p>
-          </div>
-        </div>
+			<div className="p-6 pt-8">
+				<div className="flex items-start space-x-3 mb-4">
+					<div className="flex-shrink-0 w-12 h-12 bg-slate-700 rounded-lg flex items-center justify-center text-yellow-400">
+						{icon}
+					</div>
+					<div className="flex-1">
+						<h3 className="text-lg font-bold text-slate-800 mb-1">
+							{quest.title}
+						</h3>
+						<p className="text-sm text-slate-600 line-clamp-3">
+							{quest.description}
+						</p>
+					</div>
+				</div>
 
-        <div className="flex flex-wrap gap-2 mb-4">
-          {(quest.tags ?? []).map((tag, index) => (
-            <span
-              key={`${quest.id}-${tag}-${index}`}
-              className="px-2 py-1 bg-slate-200 text-slate-700 text-xs rounded-full font-medium"
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
+				<div className="flex flex-wrap gap-2 mb-4">
+					{(quest.tags ?? []).map((tag, index) => (
+						<span
+							key={`${quest.id}-${tag}-${index}`}
+							className="px-2 py-1 bg-slate-200 text-slate-700 text-xs rounded-full font-medium"
+						>
+							{tag}
+						</span>
+					))}
+				</div>
 
-        <div className="space-y-2 mb-4 text-sm text-slate-600">
-          <div className="flex items-center justify-between">
-            <span>タイプ:</span>
-            <span className="font-semibold capitalize">{quest.type}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>難易度:</span>
-            <span className="font-semibold">{quest.difficulty || "未設定"}</span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>報酬:</span>
-            <span className="font-semibold text-slate-800">
-              {formatCurrency(quest.rewards?.incentive_amount)}
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>参加者:</span>
-            <span className="font-semibold">
-              {participantCount}/{quest.maxParticipants}名
-            </span>
-          </div>
-          <div className="flex items-center justify-between">
-            <span>期限:</span>
-            <span className="font-semibold text-xs">
-              {formatDate(quest.end_date)}
-            </span>
-          </div>
-        </div>
+				<div className="space-y-2 mb-4 text-sm text-slate-600">
+					<div className="flex items-center justify-between">
+						<span>タイプ:</span>
+						<span className="font-semibold capitalize">{quest.type}</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span>難易度:</span>
+						<span className="font-semibold">
+							{quest.difficulty || "未設定"}
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span>報酬:</span>
+						<span className="font-semibold text-slate-800">
+							{formatCurrency(quest.rewards?.incentive_amount)}
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span>参加者:</span>
+						<span className="font-semibold">
+							{participantCount}/{quest.maxParticipants}名
+						</span>
+					</div>
+					<div className="flex items-center justify-between">
+						<span>期限:</span>
+						<span className="font-semibold text-xs">
+							{formatDate(quest.end_date)}
+						</span>
+					</div>
+				</div>
 
-        {quest.quest_participants && quest.quest_participants.length > 0 && (
-          <div className="mb-4">
-            <div className="text-xs text-slate-600 mb-2">参加メンバー:</div>
-            <div className="flex flex-wrap gap-1">
-              {quest.quest_participants.slice(0, 3).map((participant, index) => (
-                <span
-                  key={`${participant.user.id}-${index}`}
-                  className="px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full font-medium"
-                >
-                  {participant.user.name}
-                </span>
-              ))}
-              {quest.quest_participants.length > 3 && (
-                <span className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full font-medium">
-                  +{quest.quest_participants.length - 3}名
-                </span>
-              )}
-            </div>
-          </div>
-        )}
+				{quest.quest_participants && quest.quest_participants.length > 0 && (
+					<div className="mb-4">
+						<div className="text-xs text-slate-600 mb-2">参加メンバー:</div>
+						<div className="flex flex-wrap gap-1">
+							{quest.quest_participants
+								.slice(0, 3)
+								.map((participant, index) => (
+									<span
+										key={`${participant.user.id}-${index}`}
+										className="px-2 py-1 bg-blue-100 text-blue-700 text-xs rounded-full font-medium"
+									>
+										{participant.user.name}
+									</span>
+								))}
+							{quest.quest_participants.length > 3 && (
+								<span className="px-2 py-1 bg-gray-100 text-gray-600 text-xs rounded-full font-medium">
+									+{quest.quest_participants.length - 3}名
+								</span>
+							)}
+						</div>
+					</div>
+				)}
 
-        <div className="mb-4">
-          <div className="flex items-center justify-between text-xs text-slate-600 mb-1">
-            <span>参加状況</span>
-            <span>{progressPercent}%</span>
-          </div>
-          <div className="w-full bg-slate-300 rounded-full h-2">
-            <div
-              className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all duration-300"
-              style={{ width: `${progressPercent}%` }}
-            ></div>
-          </div>
-        </div>
+				<div className="mb-4">
+					<div className="flex items-center justify-between text-xs text-slate-600 mb-1">
+						<span>参加状況</span>
+						<span>{progressPercent}%</span>
+					</div>
+					<div className="w-full bg-slate-300 rounded-full h-2">
+						<div
+							className="bg-gradient-to-r from-blue-500 to-blue-600 h-2 rounded-full transition-all duration-300"
+							style={{ width: `${progressPercent}%` }}
+						/>
+					</div>
+				</div>
 
-        {quest.status === "active" ? (
-          <button
-            onClick={() => onJoin(quest)}
-            className="w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:from-blue-700 hover:to-blue-800"
-          >
-            クエストに参加する
-          </button>
-        ) : quest.status === "completed" ? (
-          completedButtonAction ? (
-            <button
-              onClick={completedButtonAction.action}
-              className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${completedButtonAction.className}`}
-            >
-              <div className="flex items-center justify-center gap-2">
-                {CompletedIcon && <CompletedIcon className="w-4 h-4" />}
-                {completedButtonAction.text}
-              </div>
-            </button>
-          ) : (
-            <button
-              disabled
-              className="w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform shadow-md bg-gray-300 text-gray-500 cursor-not-allowed"
-            >
-              <div className="flex items-center justify-center gap-2">
-                <Search className="w-4 h-4" />
-                読み込み中...
-              </div>
-            </button>
-          )
-        ) : (
-          <button
-            className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${
-              quest.status === "in_progress"
-                ? "bg-gradient-to-r from-amber-500 to-amber-600 text-white cursor-not-allowed opacity-75"
-                : "bg-gradient-to-r from-gray-500 to-gray-600 text-white cursor-not-allowed opacity-75"
-            }`}
-            disabled
-          >
-            {quest.status === "in_progress" ? (
-              "クエスト進行中"
-            ) : (
-              <div className="flex items-center justify-center gap-2">
-                <Eye className="w-4 h-4" />
-                クエスト停止中
-              </div>
-            )}
-          </button>
-        )}
-      </div>
-    </div>
-  );
+				{quest.status === "active" ? (
+					<button
+						type="button"
+						onClick={() => onJoin(quest)}
+						className="w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg bg-gradient-to-r from-blue-600 to-blue-700 text-white hover:from-blue-700 hover:to-blue-800"
+					>
+						クエストに参加する
+					</button>
+				) : quest.status === "completed" ? (
+					completedButtonAction ? (
+						<button
+							type="button"
+							onClick={completedButtonAction.action}
+							className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${completedButtonAction.className}`}
+						>
+							<div className="flex items-center justify-center gap-2">
+								{CompletedIcon && <CompletedIcon className="w-4 h-4" />}
+								{completedButtonAction.text}
+							</div>
+						</button>
+					) : (
+						<button
+							type="button"
+							disabled
+							className="w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform shadow-md bg-gray-300 text-gray-500 cursor-not-allowed"
+						>
+							<div className="flex items-center justify-center gap-2">
+								<Search className="w-4 h-4" />
+								読み込み中...
+							</div>
+						</button>
+					)
+				) : (
+					<button
+						type="button"
+						className={`w-full py-3 px-4 rounded-lg font-semibold transition-all duration-300 transform hover:scale-105 shadow-md hover:shadow-lg ${
+							quest.status === "in_progress"
+								? "bg-gradient-to-r from-amber-500 to-amber-600 text-white cursor-not-allowed opacity-75"
+								: "bg-gradient-to-r from-gray-500 to-gray-600 text-white cursor-not-allowed opacity-75"
+						}`}
+						disabled
+					>
+						{quest.status === "in_progress" ? (
+							"クエスト進行中"
+						) : (
+							<div className="flex items-center justify-center gap-2">
+								<Eye className="w-4 h-4" />
+								クエスト停止中
+							</div>
+						)}
+					</button>
+				)}
+			</div>
+		</div>
+	);
 };
 
 export default QuestListCard;

--- a/apps/frontend/src/components/organisms/questListFilters.ts
+++ b/apps/frontend/src/components/organisms/questListFilters.ts
@@ -1,73 +1,75 @@
-import { type Quest } from "@quest-board/types";
+import type { Quest, QuestStatusValue } from "@quest-board/types";
 
 type QuestListFilterParams = {
-  selectedFilter: string;
-  normalizedSearchQuery: string;
-  startDateFilter: string;
-  endDateFilter: string;
-  hiddenStatuses: readonly string[];
+	selectedFilter: string;
+	normalizedSearchQuery: string;
+	startDateFilter: string;
+	endDateFilter: string;
+	hiddenStatuses: readonly QuestStatusValue[];
 };
 
 const toDateKey = (dateValue: string) => dateValue.slice(0, 10);
 
 const matchesQuestFilter = (
-  quest: Quest,
-  {
-    selectedFilter,
-    normalizedSearchQuery,
-    startDateFilter,
-    endDateFilter,
-    hiddenStatuses,
-  }: QuestListFilterParams
+	quest: Quest,
+	{
+		selectedFilter,
+		normalizedSearchQuery,
+		startDateFilter,
+		endDateFilter,
+		hiddenStatuses,
+	}: QuestListFilterParams,
 ) => {
-  const isHiddenStatus = hiddenStatuses.includes(quest.status as string);
-  if (isHiddenStatus) {
-    return false;
-  }
+	const isHiddenStatus = hiddenStatuses.includes(
+		quest.status as QuestStatusValue,
+	);
+	if (isHiddenStatus) {
+		return false;
+	}
 
-  const matchesFilter =
-    selectedFilter === "all" || quest.status === selectedFilter;
-  if (!matchesFilter) {
-    return false;
-  }
+	const matchesFilter =
+		selectedFilter === "all" || quest.status === selectedFilter;
+	if (!matchesFilter) {
+		return false;
+	}
 
-  const matchesSearch =
-    normalizedSearchQuery.length === 0 ||
-    quest.title.toLowerCase().includes(normalizedSearchQuery) ||
-    quest.description.toLowerCase().includes(normalizedSearchQuery) ||
-    (quest.tags ?? []).some((tag) =>
-      tag.toLowerCase().includes(normalizedSearchQuery)
-    );
-  if (!matchesSearch) {
-    return false;
-  }
+	const matchesSearch =
+		normalizedSearchQuery.length === 0 ||
+		quest.title.toLowerCase().includes(normalizedSearchQuery) ||
+		quest.description.toLowerCase().includes(normalizedSearchQuery) ||
+		(quest.tags ?? []).some((tag) =>
+			tag.toLowerCase().includes(normalizedSearchQuery),
+		);
+	if (!matchesSearch) {
+		return false;
+	}
 
-  const questStartDate = toDateKey(quest.start_date);
-  const matchesStartDate =
-    !startDateFilter || questStartDate >= startDateFilter;
-  const matchesEndDate = !endDateFilter || questStartDate <= endDateFilter;
+	const questStartDate = toDateKey(quest.start_date);
+	const matchesStartDate =
+		!startDateFilter || questStartDate >= startDateFilter;
+	const matchesEndDate = !endDateFilter || questStartDate <= endDateFilter;
 
-  return matchesStartDate && matchesEndDate;
+	return matchesStartDate && matchesEndDate;
 };
 
 export const filterQuests = (
-  quests: Quest[],
-  params: QuestListFilterParams
+	quests: Quest[],
+	params: QuestListFilterParams,
 ) => {
-  return quests.filter((quest) => matchesQuestFilter(quest, params));
+	return quests.filter((quest) => matchesQuestFilter(quest, params));
 };
 
 export const getSuggestedQuests = (
-  quests: Quest[],
-  params: QuestListFilterParams
+	quests: Quest[],
+	params: QuestListFilterParams,
 ) => {
-  if (params.normalizedSearchQuery.length === 0) {
-    return [];
-  }
+	if (params.normalizedSearchQuery.length === 0) {
+		return [];
+	}
 
-  return filterQuests(quests, params)
-    .filter((quest) =>
-      quest.title.toLowerCase().includes(params.normalizedSearchQuery)
-    )
-    .slice(0, 5);
+	return filterQuests(quests, params)
+		.filter((quest) =>
+			quest.title.toLowerCase().includes(params.normalizedSearchQuery),
+		)
+		.slice(0, 5);
 };

--- a/apps/frontend/src/constants/questPresentation.ts
+++ b/apps/frontend/src/constants/questPresentation.ts
@@ -1,0 +1,88 @@
+import {
+	QUEST_STATUS_LABELS,
+	QUEST_STATUS_VALUES,
+	QuestDifficulty,
+	QuestStatus,
+	type QuestStatusValue,
+	QuestType,
+} from "@quest-board/types";
+
+export const HIDDEN_QUEST_STATUSES: readonly QuestStatusValue[] = [
+	QuestStatus.Draft,
+	QuestStatus.Pending,
+	QuestStatus.Inactive,
+];
+
+const QUEST_STATUS_BADGE_CLASSES: Record<QuestStatusValue, string> = {
+	[QuestStatus.Pending]: "bg-yellow-500",
+	[QuestStatus.Active]: "bg-blue-500",
+	[QuestStatus.Completed]: "bg-green-500",
+	[QuestStatus.Draft]: "bg-gray-500",
+	[QuestStatus.InProgress]: "bg-purple-500",
+	[QuestStatus.Inactive]: "bg-gray-400",
+};
+
+const QUEST_DIFFICULTY_BADGE_CLASSES: Record<QuestDifficulty, string> = {
+	[QuestDifficulty.Beginner]: "bg-green-500",
+	[QuestDifficulty.Intermediate]: "bg-yellow-500",
+	[QuestDifficulty.Advanced]: "bg-red-500",
+};
+
+const questStatusSet = new Set<string>(QUEST_STATUS_VALUES);
+
+const isQuestStatusValue = (value: string): value is QuestStatusValue => {
+	return questStatusSet.has(value);
+};
+
+export const getQuestStatusLabel = (status: string): string => {
+	if (!isQuestStatusValue(status)) {
+		return status;
+	}
+	return QUEST_STATUS_LABELS[status];
+};
+
+export const getQuestStatusBadgeClass = (status: string): string => {
+	if (!isQuestStatusValue(status)) {
+		return "bg-gray-500";
+	}
+	return QUEST_STATUS_BADGE_CLASSES[status];
+};
+
+export const getQuestDifficultyBadgeClass = (
+	difficulty?: QuestDifficulty,
+): string => {
+	if (!difficulty) {
+		return "bg-gray-500";
+	}
+	return QUEST_DIFFICULTY_BADGE_CLASSES[difficulty] ?? "bg-gray-500";
+};
+
+type QuestTypeIconKind = "wrench" | "book" | "sword";
+
+export const getQuestTypeIconKind = (type?: string): QuestTypeIconKind => {
+	switch (type) {
+		case QuestType.Development:
+			return "wrench";
+		case QuestType.Learning:
+			return "book";
+		case QuestType.Challenge:
+		case QuestType.Planning:
+		case QuestType.Maintenance:
+		case QuestType.Design:
+			return "sword";
+		default:
+			return "sword";
+	}
+};
+
+export type QuestRibbonStatus = "participating" | "completed" | "applied";
+
+export const getQuestRibbonStatus = (status?: string): QuestRibbonStatus => {
+	if (status === QuestStatus.Active || status === QuestStatus.InProgress) {
+		return "participating";
+	}
+	if (status === QuestStatus.Completed || status === "cleared") {
+		return "completed";
+	}
+	return "applied";
+};

--- a/apps/frontend/src/services/auth/signUp.ts
+++ b/apps/frontend/src/services/auth/signUp.ts
@@ -1,80 +1,60 @@
+import { auth, db } from "@/services/firebase";
+import { authenticatedApiClient } from "@/services/httpClient";
 import { createUserWithEmailAndPassword, updateProfile } from "firebase/auth";
 import { doc, setDoc } from "firebase/firestore";
-import { auth, db } from "@/services/firebase";
-import { getIdToken } from "@/services/firebase";
 
 export const signUp = async (name: string, email: string, password: string) => {
-  try {
-    // 1. Firebase Authenticationでアカウント作成
-    const userCredential = await createUserWithEmailAndPassword(
-      auth,
-      email,
-      password
-    );
+	try {
+		// 1. Firebase Authenticationでアカウント作成
+		const userCredential = await createUserWithEmailAndPassword(
+			auth,
+			email,
+			password,
+		);
 
-    if (auth.currentUser) {
-      // 2. FirebaseのユーザープロファイルにdisplayNameを設定
-      await updateProfile(auth.currentUser, {
-        displayName: name,
-      });
-      await auth.currentUser.reload();
+		if (auth.currentUser) {
+			// 2. FirebaseのユーザープロファイルにdisplayNameを設定
+			await updateProfile(auth.currentUser, {
+				displayName: name,
+			});
+			await auth.currentUser.reload();
 
-      // 3. Firestoreにユーザーロール情報を保存（デフォルトは"user"）
-      try {
-        const userDocRef = doc(db, "users", auth.currentUser.uid);
-        const userData = {
-          uid: auth.currentUser.uid,
-          displayName: name,
-          email: email,
-          role: "user",
-          createdAt: new Date(),
-        };
+			// 3. Firestoreにユーザーロール情報を保存（デフォルトは"user"）
+			try {
+				const userDocRef = doc(db, "users", auth.currentUser.uid);
+				const userData = {
+					uid: auth.currentUser.uid,
+					displayName: name,
+					email: email,
+					role: "user",
+					createdAt: new Date(),
+				};
 
-        await setDoc(userDocRef, userData);
-      } catch (firestoreError: unknown) {
-        console.error("Firestore保存エラー:", firestoreError);
-        console.warn(
-          "Firestoreへの保存に失敗しましたが、アカウント作成は成功しています"
-        );
-      }
+				await setDoc(userDocRef, userData);
+			} catch (firestoreError: unknown) {
+				console.error("Firestore保存エラー:", firestoreError);
+				console.warn(
+					"Firestoreへの保存に失敗しましたが、アカウント作成は成功しています",
+				);
+			}
 
-      // 4. バックエンドのMySQLデータベースにもユーザー情報を保存
-      try {
-        const idToken = await getIdToken();
-        const apiUrl = `${
-          process.env.NEXT_PUBLIC_API_BASE_URL || "http://localhost:3001"
-        }/api/users`;
+			// 4. バックエンドのMySQLデータベースにもユーザー情報を保存
+			try {
+				await authenticatedApiClient.post("/users", {
+					name: name,
+					role: "user",
+				});
+			} catch (error: unknown) {
+				console.error("バックエンド同期エラー:", error);
+				console.warn(
+					"Firebaseでのアカウント作成は成功しましたが、バックエンドとの同期に失敗しました",
+				);
+			}
+		}
 
-        const response = await fetch(apiUrl, {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-            Authorization: `Bearer ${idToken}`,
-          },
-          body: JSON.stringify({
-            name: name,
-            role: "user",
-          }),
-        });
-
-        if (!response.ok) {
-          const errorData = await response.json();
-          console.error("バックエンドユーザー作成エラー:", errorData);
-          console.warn(
-            "Firebaseでのアカウント作成は成功しましたが、バックエンドとの同期に失敗しました"
-          );
-        }
-      } catch (error: unknown) {
-        console.error("バックエンド同期エラー:", error);
-        console.warn(
-          "Firebaseでのアカウント作成は成功しましたが、バックエンドとの同期に失敗しました"
-        );
-      }
-    }
-
-    return userCredential;
-  } catch (error: unknown) {
-    console.error("サインアップエラー:", error);
-    throw error;
-  }
+		return userCredential;
+	} catch (error: unknown) {
+		console.error("サインアップエラー:", error);
+		throw error;
+	}
 };

--- a/apps/frontend/src/types/quest.ts
+++ b/apps/frontend/src/types/quest.ts
@@ -1,1 +1,0 @@
-export * from "@quest-board/types";


### PR DESCRIPTION
## Summary
- frontend の API 呼び出しを `authenticatedApiClient` / 共通 presentation helper に寄せた
- Quest status/type/difficulty の表示ルールを `questPresentation` に集約した
- E2E の接続先 env 名を `API_BASE_URL` / `FRONTEND_BASE_URL` に統一し、serial 実行設定を明示した
- 未使用の E2E テスト補助コードを削除し、型参照を整理した

## Verification
- `pnpm --filter frontend test`
- `pnpm --filter frontend exec tsc --noEmit`
- `pnpm --filter e2e exec tsc --noEmit`

## Notes
- `apps/e2e` の API デフォルトポートは backend 開発サーバに合わせて `3001` を前提にしています
- review API の認証変更を含む差分取り込み時は、最新 main ベースで E2E 再確認が必要です
- pre-commit の `frontend test:precommit` は rollup optional dependency (`@rollup/rollup-darwin-x64`) 解決失敗で hook 実行時のみ落ちたため、上記コマンドを個別実行して確認しました
- related issue: #161
