### PR TITLE
fix: backend の env と Prisma 手順を安定化する (#58)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,20 +42,13 @@ repo
 │  ├─ backend    # API、service、Prisma、認証
 │  ├─ docs       # 開発ドキュメントサイト
 │  └─ e2e        # Playwright E2E テスト
-<<<<<<< HEAD
+├─ packages
+│  └─ types      # 共有型
 ├─ docs          # AI / 開発運用の正本ドキュメント
 ├─ prompt        # 補助テンプレート
 ├─ AGENTS.md     # AI 共通ルールの正本
 ├─ CLAUDE.md     # 互換用の案内
-└─ README.md     # セットアップと repo 全体像
-=======
-├─ packages
-│  └─ types      # 共有型
-├─ docs          # AI / 開発運用の正本ドキュメント
-├─ prompt        # エージェント用テンプレート
-├─ AGENTS.md     # AI 共通ルール
 └─ README.md     # セットアップと全体像
->>>>>>> origin/main
 ```
 
 ## 変更箇所の当たり方
@@ -72,31 +65,20 @@ repo
 | テスト | `apps/frontend/src/__tests__`, `apps/backend/src/__tests__`, `apps/e2e/tests` |
 | ルール、設計 | `AGENTS.md`, `docs/architecture.md`, `docs/ai-execution.md` |
 
-<<<<<<< HEAD
-## AI 向けドキュメント導線
-
-AI が最初に読むべき文書セットは次の 5 つです。
-=======
 ## AI向けドキュメント導線
 
-AIエージェント向けの正本は以下です。
->>>>>>> origin/main
+AI が最初に読むべき文書セットは次の 6 つです。
 
 1. `README.md`
 2. `AGENTS.md`
 3. `docs/architecture.md`
 4. `docs/ai-execution.md`
 5. `prompt/agent.md`
-<<<<<<< HEAD
 6. 関連コード / 関連テスト
-=======
-6. 関連コード / テスト
->>>>>>> origin/main
 
 役割は次のとおりです。
 
 - `README.md`: セットアップ、開発コマンド、リポジトリ全体像
-<<<<<<< HEAD
 - `AGENTS.md`: AI エージェント共通ルールの正本
 - `docs/architecture.md`: repo 構造、レイヤー責務、変更判断の基準
 - `docs/ai-execution.md`: 調査、実装、検証、報告の進め方
@@ -107,15 +89,6 @@ AIエージェント向けの正本は以下です。
 - `prompt/create_issue.md`: 改善 issue を新規起票するときの補助テンプレート
 - `prompt/modify_issue.md`: 既存 issue を整理、修正するときの補助テンプレート
 - `CLAUDE.md`: `AGENTS.md` への互換エントリ
-=======
-- `AGENTS.md`: AIエージェント共通ルール
-- `docs/architecture.md`: 実装対象の構造、責務、変更時の判断基準
-- `docs/ai-execution.md`: AIの調査、実装、検証フロー
-- `prompt/agent.md`: 他エージェントにも渡せる実行テンプレート
-- `prompt/create_issue.md`: 改善 issue を新規起票するときの補助プロンプト
-- `prompt/modify_issue.md`: 既存 issue を整理、修正するときの補助プロンプト
-- `ai-docs-refactor-prompt.md`: AI 向け docs 自体を見直すときの補助プロンプト
->>>>>>> origin/main
 
 ---
 
@@ -199,6 +172,7 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY----
 
 # Prisma / MySQL（docker-compose.yml のデフォルト値に合わせて設定）
 DATABASE_URL=mysql://app_user:app_password@localhost:3306/your_project_db
+SHADOW_DATABASE_URL=mysql://app_user:app_password@localhost:3306/your_project_shadow_db
 MYSQL_ROOT_PASSWORD=rootpassword
 MYSQL_DATABASE=your_project_db
 MYSQL_USER=app_user
@@ -248,7 +222,12 @@ pnpm db:generate
 
 # スキーマをデータベースに反映
 pnpm db:push
+
+# migration を適用する場合（任意）
+pnpm --filter backend prisma:migrate:deploy
 ```
+
+`pnpm dev:backend` と backend の test は `apps/backend/.env.local` を基準に環境変数を読むため、repo root と `apps/backend` のどちらから実行しても同じ `DATABASE_URL` を参照できます。
 
 ---
 
@@ -287,6 +266,7 @@ pnpm dev:docs
 | `pnpm db:generate` | Prisma クライアントを生成 |
 | `pnpm db:push` | スキーマをDBに反映 |
 | `pnpm db:studio` | Prisma Studio（DB GUI）を起動 |
+| `pnpm --filter backend prisma:migrate:deploy` | backend の migration を適用 |
 
 ---
 

--- a/apps/backend/.env.local.example
+++ b/apps/backend/.env.local.example
@@ -5,6 +5,7 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----E
 
 # Prisma / MySQL（docker-compose.yml のデフォルト値に合わせる）
 DATABASE_URL=mysql://app_user:app_password@localhost:3306/your_project_db
+SHADOW_DATABASE_URL=mysql://app_user:app_password@localhost:3306/your_project_shadow_db
 MYSQL_ROOT_PASSWORD=rootpassword
 MYSQL_DATABASE=your_project_db
 MYSQL_USER=app_user

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,49 +1,51 @@
 {
-  "name": "backend",
-  "private": true,
-  "scripts": {
-    "dev": "tsx watch src/app.ts",
-    "build": "tsc",
-    "openapi:diff-to-zod": "tsx scripts/openapiDiffToZod.ts",
-    "prisma:generate": "prisma generate --schema prisma/schema.prisma",
-    "seed": "tsx prisma/seed.ts",
-    "seed:inactive": "tsx prisma/add-inactive-quests.ts",
-    "start": "node dist/app.js",
-    "test": "jest",
-    "typecheck": "tsc --noEmit",
-    "test:prepush": "pnpm typecheck && pnpm test --runInBand",
-    "test:watch": "jest --watch",
-    "test:coverage": "jest --coverage"
-  },
-  "prisma": {
-    "seed": "tsx prisma/seed.ts"
-  },
-  "dependencies": {
-    "@asteasolutions/zod-to-openapi": "^7.3.4",
-    "@prisma/client": "5.22.0",
-    "@quest-board/types": "workspace:*",
-    "cors": "^2.8.5",
-    "dotenv": "^16.0.0",
-    "express": "^4.18.0",
-    "firebase-admin": "^13.7.0",
-    "helmet": "^7.0.0",
-    "pino": "^10.3.1",
-    "pino-http": "^11.0.0",
-    "pino-pretty": "^13.1.3",
-    "prisma": "^5.22.0",
-    "swagger-ui-express": "^5.0.1",
-    "zod": "^3.24.2"
-  },
-  "devDependencies": {
-    "@types/cors": "^2.8.0",
-    "@types/express": "^4.17.0",
-    "@types/jest": "^29.5.0",
-    "@types/node": "^20.0.0",
-    "@types/swagger-ui-express": "^4.1.8",
-    "jest": "^29.5.0",
-    "nodemon": "^3.0.0",
-    "ts-jest": "^29.1.0",
-    "tsx": "^4.0.0",
-    "typescript": "^5.0.0"
-  }
+	"name": "backend",
+	"private": true,
+	"scripts": {
+		"dev": "tsx watch src/app.ts",
+		"build": "tsc",
+		"openapi:diff-to-zod": "tsx scripts/openapiDiffToZod.ts",
+		"prisma:generate": "prisma generate --schema prisma/schema.prisma",
+		"prisma:db:push": "prisma db push --schema prisma/schema.prisma",
+		"prisma:migrate:deploy": "prisma migrate deploy --schema prisma/schema.prisma",
+		"seed": "tsx prisma/seed.ts",
+		"seed:inactive": "tsx prisma/add-inactive-quests.ts",
+		"start": "node dist/app.js",
+		"test": "jest",
+		"typecheck": "tsc --noEmit",
+		"test:prepush": "pnpm typecheck && pnpm test --runInBand",
+		"test:watch": "jest --watch",
+		"test:coverage": "jest --coverage"
+	},
+	"prisma": {
+		"seed": "tsx prisma/seed.ts"
+	},
+	"dependencies": {
+		"@asteasolutions/zod-to-openapi": "^7.3.4",
+		"@prisma/client": "5.22.0",
+		"@quest-board/types": "workspace:*",
+		"cors": "^2.8.5",
+		"dotenv": "^16.0.0",
+		"express": "^4.18.0",
+		"firebase-admin": "^13.7.0",
+		"helmet": "^7.0.0",
+		"pino": "^10.3.1",
+		"pino-http": "^11.0.0",
+		"pino-pretty": "^13.1.3",
+		"prisma": "^5.22.0",
+		"swagger-ui-express": "^5.0.1",
+		"zod": "^3.24.2"
+	},
+	"devDependencies": {
+		"@types/cors": "^2.8.0",
+		"@types/express": "^4.17.0",
+		"@types/jest": "^29.5.0",
+		"@types/node": "^20.0.0",
+		"@types/swagger-ui-express": "^4.1.8",
+		"jest": "^29.5.0",
+		"nodemon": "^3.0.0",
+		"ts-jest": "^29.1.0",
+		"tsx": "^4.0.0",
+		"typescript": "^5.0.0"
+	}
 }

--- a/apps/backend/src/__tests__/config/env.test.ts
+++ b/apps/backend/src/__tests__/config/env.test.ts
@@ -1,36 +1,80 @@
+import { resolve } from "node:path";
+
 describe("config/env", () => {
-  const originalDatabaseUrl = process.env.DATABASE_URL;
+	const originalDatabaseUrl = process.env.DATABASE_URL;
+	const originalCwd = process.cwd();
 
-  afterEach(() => {
-    jest.resetModules();
+	afterEach(() => {
+		jest.resetModules();
+		jest.restoreAllMocks();
+		process.chdir(originalCwd);
 
-    if (originalDatabaseUrl === undefined) {
-      delete process.env.DATABASE_URL;
-      return;
-    }
+		if (originalDatabaseUrl === undefined) {
+			process.env.DATABASE_URL = "";
+			return;
+		}
 
-    process.env.DATABASE_URL = originalDatabaseUrl;
-  });
+		process.env.DATABASE_URL = originalDatabaseUrl;
+	});
 
-  it("DATABASE_URL が未設定なら分かりやすいエラーを投げる", () => {
-    delete process.env.DATABASE_URL;
+	it("DATABASE_URL が未設定なら分かりやすいエラーを投げる", () => {
+		process.env.DATABASE_URL = "";
+		jest.doMock("dotenv", () => ({
+			config: jest.fn(),
+		}));
+		jest.doMock("node:fs", () => ({
+			existsSync: () => false,
+		}));
 
-    expect(() => {
-      jest.isolateModules(() => {
-        require("@/config/env");
-      });
-    }).toThrow(
-      "DATABASE_URL が未設定です。apps/backend/.env.local を確認してください。"
-    );
-  });
+		expect(() => {
+			jest.isolateModules(() => {
+				require("@/config/env");
+			});
+		}).toThrow(
+			"DATABASE_URL が未設定です。apps/backend/.env.local を確認してください。",
+		);
+	});
 
-  it("DATABASE_URL が設定済みならそのまま読み込める", () => {
-    process.env.DATABASE_URL = "mysql://user:password@localhost:3306/test_db";
+	it("DATABASE_URL が設定済みならそのまま読み込める", () => {
+		process.env.DATABASE_URL = "mysql://user:password@localhost:3306/test_db";
 
-    expect(() => {
-      jest.isolateModules(() => {
-        require("@/config/env");
-      });
-    }).not.toThrow();
-  });
+		expect(() => {
+			jest.isolateModules(() => {
+				require("@/config/env");
+			});
+		}).not.toThrow();
+	});
+
+	it("repo root から実行しても apps/backend/.env.local を探索できる", () => {
+		process.env.DATABASE_URL = "";
+		process.chdir(resolve(__dirname, "../../../../.."));
+
+		const configMock = jest.fn((options?: { path?: string }) => {
+			if (options?.path?.endsWith("apps/backend/.env.local")) {
+				process.env.DATABASE_URL =
+					"mysql://user:password@localhost:3306/from-root";
+			}
+
+			return { parsed: {} };
+		});
+
+		jest.doMock("dotenv", () => ({
+			config: configMock,
+		}));
+		jest.doMock("node:fs", () => ({
+			existsSync: (path: string) => path.endsWith("apps/backend/.env.local"),
+		}));
+
+		expect(() => {
+			jest.isolateModules(() => {
+				require("@/config/env");
+			});
+		}).not.toThrow();
+
+		expect(configMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				path: expect.stringMatching(/apps\/backend\/\.env\.local$/),
+			}),
+		);
+	});
 });

--- a/apps/backend/src/__tests__/config/env.test.ts
+++ b/apps/backend/src/__tests__/config/env.test.ts
@@ -10,7 +10,7 @@ describe("config/env", () => {
 		process.chdir(originalCwd);
 
 		if (originalDatabaseUrl === undefined) {
-			process.env.DATABASE_URL = "";
+			Reflect.deleteProperty(process.env, "DATABASE_URL");
 			return;
 		}
 
@@ -18,7 +18,7 @@ describe("config/env", () => {
 	});
 
 	it("DATABASE_URL が未設定なら分かりやすいエラーを投げる", () => {
-		process.env.DATABASE_URL = "";
+		Reflect.deleteProperty(process.env, "DATABASE_URL");
 		jest.doMock("dotenv", () => ({
 			config: jest.fn(),
 		}));
@@ -46,7 +46,7 @@ describe("config/env", () => {
 	});
 
 	it("repo root から実行しても apps/backend/.env.local を探索できる", () => {
-		process.env.DATABASE_URL = "";
+		Reflect.deleteProperty(process.env, "DATABASE_URL");
 		process.chdir(resolve(__dirname, "../../../../.."));
 
 		const configMock = jest.fn((options?: { path?: string }) => {

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -1,11 +1,28 @@
+import { existsSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import * as dotenv from "dotenv";
-import { join } from "node:path";
 
-dotenv.config({ path: join(process.cwd(), ".env.local") });
+const backendRoot = resolve(dirname(__dirname), "..");
+
+const envCandidates = [
+	resolve(process.cwd(), ".env.local"),
+	resolve(process.cwd(), "apps/backend/.env.local"),
+	resolve(backendRoot, ".env.local"),
+];
+
+for (const path of [...new Set(envCandidates)]) {
+	if (!existsSync(path)) {
+		continue;
+	}
+
+	dotenv.config({ path });
+	break;
+}
+
 dotenv.config();
 
 if (!process.env.DATABASE_URL) {
-  throw new Error(
-    "DATABASE_URL が未設定です。apps/backend/.env.local を確認してください。"
-  );
+	throw new Error(
+		"DATABASE_URL が未設定です。apps/backend/.env.local を確認してください。",
+	);
 }

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -10,16 +10,23 @@ const envCandidates = [
 	resolve(backendRoot, ".env.local"),
 ];
 
+let loadedFromCandidate = false;
+
+// process.cwd() と backendRoot が同じ解決結果になるケースの重複を除外する。
 for (const path of [...new Set(envCandidates)]) {
 	if (!existsSync(path)) {
 		continue;
 	}
 
 	dotenv.config({ path });
+	loadedFromCandidate = true;
 	break;
 }
 
-dotenv.config();
+// .env.local が見つからない場合のみ、従来互換でデフォルトの .env を読む。
+if (!loadedFromCandidate) {
+	dotenv.config();
+}
 
 if (!process.env.DATABASE_URL) {
 	throw new Error(

--- a/apps/backend/src/config/env.ts
+++ b/apps/backend/src/config/env.ts
@@ -13,14 +13,18 @@ const envCandidates = [
 let loadedFromCandidate = false;
 
 // process.cwd() と backendRoot が同じ解決結果になるケースの重複を除外する。
+// ファイルが存在しても DATABASE_URL が未設定なら次の候補へ進む。
 for (const path of [...new Set(envCandidates)]) {
 	if (!existsSync(path)) {
 		continue;
 	}
 
 	dotenv.config({ path });
-	loadedFromCandidate = true;
-	break;
+
+	if (process.env.DATABASE_URL) {
+		loadedFromCandidate = true;
+		break;
+	}
 }
 
 // .env.local が見つからない場合のみ、従来互換でデフォルトの .env を読む。


### PR DESCRIPTION
## Summary
- backend の env 読み込みを `apps/backend/.env.local` 基準で安定化した
- `.env.local` が見つからない場合のみ既定の `dotenv.config()` にフォールバックするよう整理した
- env 探索の単体テストを追加し、Prisma 用の手順と設定を補強した

## Verification
- `pnpm db:generate`
- `pnpm --filter backend test -- --runTestsByPath src/__tests__/config/env.test.ts`
- `pnpm --filter backend typecheck`

## Notes
- `envCandidates` の重複除外意図が分かるようコメントを補いました
- README に残っていた conflict marker もこの文脈で解消しています
- related issue: #58
