### PR TITLE
docs: AGENTS.md / CLAUDE.md にコマンド要約・Issue規約・Claude向け修正を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,9 +52,19 @@ prisma/migrations/
 *.db-journal
 
 # Mac/Windows system files
-.DS_Store
-docs/.DS_Store
+**/.DS_Store
 Thumbs.db
 
 # VSCode
 .vscode/
+
+# E2E test outputs
+playwright-report/
+test-results/
+
+# Git worktrees (local working directories)
+.worktrees/
+.codex/
+
+# Claude Code local configuration
+.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,64 +1,31 @@
-# AI Agent Rules
+# Codex Rules
 
-このリポジトリで作業する AI エージェントは、このファイルを最優先の共通ルールとして扱う。
+このファイルは Codex / OpenAI エージェント向けのルールファイルです。
+Claude Code を使う場合は CLAUDE.md を参照してください。
 
-<<<<<<< HEAD
-## 参照順序
+## Commands
 
-=======
->>>>>>> origin/main
-作業開始時の参照順序:
+詳細は README.md 参照。主要コマンドのみ抜粋:
 
-1. ユーザーの最新依頼
-2. `README.md`
-3. `AGENTS.md`
-4. `docs/architecture.md`
-5. `docs/ai-execution.md`
-6. `prompt/agent.md`
-7. 関連コード / 関連テスト
-
-判断が衝突した場合の優先順位:
-
-1. ユーザーの最新依頼
-2. `AGENTS.md`
-3. `docs/ai-execution.md`
-4. `docs/architecture.md`
-5. `README.md`
-6. 補助 prompt / 互換 docs
-
-<<<<<<< HEAD
-## 責務
-
-- このファイルは AI エージェント共通ルールのみを定義する
-- システム構造とレイヤー責務は `docs/architecture.md` に集約する
-- 実行フローと検証方針は `docs/ai-execution.md` に集約する
-- 他エージェント向けの短い依頼テンプレートは `prompt/agent.md` に置く
-- セットアップや repo 全体像は `README.md` を正本とする
+```bash
+pnpm dev                    # 全サービス並列起動
+pnpm build                  # 全体ビルド (docs -> frontend -> backend)
+pnpm lint / pnpm lint:fix   # Biome check / 自動修正
+pnpm --filter backend test  # Jest (バックエンド)
+pnpm --filter frontend test # Vitest (フロントエンド)
+pnpm --filter backend typecheck
+docker compose up -d        # MySQL 起動 (DB 操作前に必要)
+pnpm db:push                # Prisma スキーマを DB に反映
+pnpm --filter backend seed  # シードデータ投入
+```
 
 ## General
-=======
-責務:
-
-- このファイルは AI エージェント共通ルールのみを定義する
-- アーキテクチャの詳細は `docs/architecture.md` に集約する
-- 実行フェーズや検証手順は `docs/ai-execution.md` に集約する
-- 汎用プロンプトは `prompt/agent.md` に集約する
-- セットアップや repo 全体像は `README.md` を正本とする
-
----
-
-# General
->>>>>>> origin/main
 
 - 返答、レビューコメント、PR 本文は日本語で記述する。
 - まず既存実装と既存差分を確認し、前提を決め打ちしない。
 - ユーザーが作成した未コミット差分は勝手に戻さない。
 - 破壊的コマンドは、明示的な依頼または承認がある場合のみ実行する。
-- 調査せずに質問してはならない。
-- 不明点がある場合でも、まず既存コードから仮説を立てて進める。
-- ドキュメント間で矛盾がある場合は、ユーザー指示を除きこのファイルを優先する。
 
-<<<<<<< HEAD
 ## Git / Branch
 
 - issue 対応は原則 `git worktree` で分離する。
@@ -67,44 +34,16 @@
 - push 前に upstream との差分と競合有無を確認する。
 
 ## Editing
-=======
----
 
-# Working Flow
-
-実装作業は必ず以下の順序で行う。
-
-1. AGENTS.md を確認する
-2. 既存コードと既存差分を調査する
-3. 実装方針を決める
-4. 最小変更で実装する
-5. テストを追加する
-6. 検証を実行する
-7. 変更内容をまとめる
-
----
-
-# Git / Branch
-
-- issue 対応は原則 `git worktree` で分離する。
-- 作業ブランチは 1 issue / 1 task ごとに切る。
-- push 前に upstream との差分と競合有無を確認する。
-
----
-
-# Editing
->>>>>>> origin/main
-
-- 手動編集は `apply_patch` を使う。
-- 変更は必要最小限にとどめる。
-- unrelated な修正を混ぜない。
-<<<<<<< HEAD
+- 変更は必要最小限にとどめ、unrelated な修正を混ぜない。
 - frontend / backend / docs をまたぐ変更は、なぜまたぐ必要があるかを説明する。
+- デフォルトは ASCII を使い、既存ファイルに合わせる場合のみ例外を認める。
 
 ## Validation
 
 - 実装後は、可能な範囲でテスト、型チェック、ビルドを実行する。
 - 実装を行った場合は単体テストを追加する。
+- 単体テストのカバレッジは 80% 以上を目標とする。
 - 実行できなかった検証や、既存不具合で失敗した検証は必ず明記する。
 - pre-commit は軽い差分検証に限定する。
 - pre-push は重いローカル検証に使う。
@@ -117,37 +56,29 @@
 - 問題がなければ「追加指摘なし」を明示する。
 - 推測を含む場合は、その旨を明記する。
 
-## Issue / PR
+## Issue
 
 - issue タイトルは対象と目的が判別できる具体的な文言にする。
 - issue 本文には少なくとも `Summary` `Background` `Scope` `Acceptance Criteria` を含める。
+- 実装しない内容や保留事項がある場合は `Out of Scope` または `Notes` を明記する。
+- 検証観点や確認手順が見えている場合は `Verification` を追記する。
+- 関連 issue / PR / 設計資料がある場合は本文から参照できるようにする。
+
+## PR
+
 - PR 本文には少なくとも `Summary` と `Verification` を含める。
 - 影響範囲が広い場合は `Risks` か `Notes` を追記する。
 - hook や CI による既存失敗がある場合は、今回変更と既存失敗を切り分けて書く。
-=======
 
----
+## Hooks / CI Responsibilities
 
-# Validation
-
-実装後は以下を可能な範囲で実行する。
-
-- テスト
-- 型チェック
-- ビルド
-- hook 失敗を報告する場合は、「worktree 側の pre-commit hook は ... で実行できなかったため、... で代替した」のように対象・原因・代替確認を具体的に書く。
-
----
-
-# Question Policy
-
-質問は最後の手段とする。
-
-以下の場合のみ質問してよい。
-
-1. リポジトリ内に情報が存在しない
-2. 仕様が完全に未定義
-3. 複数の設計選択があり判断不能
-
-それ以外の場合は仮説を立てて実装する。
->>>>>>> origin/main
+- `pre-commit`
+  - formatter / linter
+  - 差分に応じた軽い静的検証
+- `pre-push`
+  - 差分に応じた重いローカル検証
+- `CI`
+  - 全体 lint
+  - 全体 typecheck
+  - build
+  - DB や外部依存を含む検証

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,39 +1,116 @@
-<<<<<<< HEAD
-# Claude Entry Point
+# CLAUDE.md
 
-このファイルは互換用の入口です。ルールの正本は `AGENTS.md` です。
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-作業前に次を確認してください。
-=======
-# Claude Guidance
+## Commands
 
-このファイルは補助的な互換ガイドです。作業ルールの source of truth は `AGENTS.md` を優先してください。
+セットアップ・環境変数の詳細は README.md を参照。主要コマンド:
 
-## Read First
->>>>>>> origin/main
+```bash
+pnpm dev                        # 全サービス並列起動 (frontend:3000 / backend:3001 / docs)
+pnpm dev:frontend | dev:backend | dev:docs  # 個別起動
+pnpm build                      # 全体ビルド (docs -> frontend -> backend の順)
+pnpm lint / pnpm lint:fix       # Biome check / 自動修正 (--apply)
 
-1. `README.md`
-2. `AGENTS.md`
-3. `docs/architecture.md`
-4. `docs/ai-execution.md`
-<<<<<<< HEAD
-5. 必要に応じて `prompt/agent.md`
-6. 関連コード / 関連テスト
+docker compose up -d            # MySQL 起動 (DB 操作前に必須)
+pnpm db:generate                # Prisma クライアント生成
+pnpm db:push                    # スキーマを DB へ反映
+pnpm db:studio                  # Prisma Studio (DB GUI)
+pnpm --filter backend seed      # シードデータ投入
+```
 
-`CLAUDE.md` 自体には repo 固有ルールを重複記載しません。更新が必要な場合は `AGENTS.md` と `docs/*` を修正してください。
-=======
-5. `CLAUDE.md` は不足分の補助参照として扱う
+### テスト・型チェック
 
-## Delegation
+```bash
+pnpm --filter backend test                 # Jest (backend, ts-jest, node 環境)
+pnpm --filter backend typecheck            # tsc --noEmit
+pnpm --filter backend test:coverage        # カバレッジ
+pnpm --filter frontend test                # Vitest (frontend, jsdom + RTL)
+pnpm --filter frontend test:coverage
 
-- 作業ルール、Issue / PR 運用、検証方針は `AGENTS.md` を参照する
-- レイヤー責務や変更起点は `docs/architecture.md` を参照する
-- 作業フロー、worktree、検証、報告の流れは `docs/ai-execution.md` を参照する
-- このファイルには `AGENTS.md` と重複する詳細ルールを持たせない
-- 互換のために残すが、更新時はまず `AGENTS.md` を修正する
+# 単一テスト
+pnpm --filter backend test -- questService.test.ts   # ファイル指定 (Jest)
+pnpm --filter backend test -- -t "作成"               # テスト名で絞り込み
+pnpm --filter frontend test -- QuestCard              # Vitest はパターン一致で実行
+pnpm --filter e2e test                                # Playwright (要 apps/e2e/.env, 起動中のサーバー)
+```
 
-## Notes
+`test:prepush` (backend) は `typecheck` と `test --runInBand` を実行する重い検証。
 
-- 返答、レビューコメント、PR 本文は日本語で記述する
-- 詳細ルールを増やさず、正本 docs への導線だけを維持する
->>>>>>> origin/main
+## アプリケーション概要
+
+「クエスト掲示板」は社内向けのタスク投稿・参加アプリ。
+
+**ユーザー種別と権限:**
+- **一般ユーザー**: クエストへの参加・レビュー投稿・マイページ閲覧
+- **管理者 (ADMIN)**: クエストの作成・編集・ステータス変更・削除復元・ユーザー管理。`constants/roles.ts` の `ROLES.ADMIN` で判定
+
+**クエストのステータス遷移:**
+```
+draft（下書き）→ pending（承認待ち、一般ユーザーが submit）
+  → active（公開中、管理者が承認）→ in_progress（進行中）→ completed（完了）
+  → inactive（停止中、管理者が一時停止）
+```
+論理削除あり（`deleted_at`）。`restore` で復元可能。`reactivate` で inactive → active に戻す。
+
+設計詳細は `apps/docs/` の VitePress サイト（`pnpm dev:docs`）を参照。要件定義・ER 図・API 一覧・コーディング規約など一式がある。
+
+## アーキテクチャ
+
+pnpm workspace のモノレポ。`apps/*` (frontend / backend / docs / e2e) と `packages/types` で構成。
+
+### backend (Express + Prisma + Firebase Admin)
+
+リクエストは**厳格な層構造**を通る。新機能は層を飛ばさず縦に追加する:
+
+```
+routes/*.ts       → URL とミドルウェア (authMiddleware / requireAdmin) の割り当て
+controllers/*.ts  → asyncHandler でラップし、validateRequest で zod 検証してから service を呼ぶ。HTTP の入出力のみ担当
+services/*.ts     → ビジネスロジック
+dataAccessor/dbAccessor/*.ts → Prisma を触る唯一の層 (Quest / User / Review など)
+```
+
+- **入力検証は `apps/backend/src/schemas/api.ts` の zod schema が single source of truth。** controller に手書きの `if` を足さず、schema を追加して `validateRequest(req, { body, params, query })` で使う。同じ schema から `src/openapi/document.ts` が OpenAPI を生成する (`GET /api/openapi.json`, Swagger UI: `/api/docs`)。
+- **エラーは `utils/appError.ts` の `AppError` / `badRequest` / `notFound` / `unauthorized` / `forbidden` を throw する。** `asyncHandler` が捕捉し、末尾の `errorHandler` ミドルウェアが JSON レスポンス化する。個々の controller で try/catch や res.status は書かない。
+- **認証**: `authMiddleware` が `Authorization: Bearer <Firebase IDトークン>` を検証して `req.user` に付与。`requireAdmin` が DB 上の `role === ROLES.ADMIN` を確認 (`constants/roles.ts`)。Firebase Admin は `config/firebase.ts` の副作用 import で初期化。
+- ログは pino (`config/logger.ts`)。`app.ts` がミドルウェア順・CORS・ルーティングを集約。
+
+### frontend (Next.js App Router + Atomic Design)
+
+- `src/app/` = App Router のページ (`login` / `signUp` / `quests/[id]` / `mypage` / `admin/dashboard`)。UI は `components/` を **atoms → molecules → organisms → pages** の atomic design で構成。
+- **API 呼び出しは必ず `src/services/httpClient.ts` 経由。** `apiClient` (公開 API) と `authenticatedApiClient` (Firebase IDトークンを自動付与) を使い分ける。fetch を直接書かない。ドメイン別ラッパーは `services/quest.ts` などにある。
+- 認証状態は `hooks/useAuth.ts`、Firebase client 初期化は `services/firebase.ts`。
+
+### packages/types
+
+`@quest-board/types` を frontend / backend 双方が import。クエストのステータス・難易度・種別などの enum とラベル、共有型を集約。**両側で使う定数・型はここに置き、二重定義しない。**
+
+## Biome について
+
+lint/format コマンドはすべて `node scripts/run-biome.cjs` 経由で呼ばれる。これは macOS/Linux/Windows でプラットフォーム固有の Biome バイナリを解決するためのラッパーで、`biome` を直接呼ぶと環境によって失敗する。`pnpm lint` / `pnpm lint:fix` を使えばラッパーが自動で使われる。
+
+## Git / Branch
+
+- issue 対応は原則 `git worktree` で分離。作業ブランチは 1 issue / 1 task ごとに切る。
+- **`main` への直接 push は pre-push フックでブロックされる。** feature ブランチから PR を出す。
+- push 前に upstream との差分と競合有無を確認する。
+
+## フックの責務
+
+- **pre-commit**: Biome format/lint (差分)。frontend に差分があれば `frontend test:precommit` も実行。軽い検証に限定。
+- **pre-push**: `main` 直 push のブロック。重いローカル検証はここに寄せる。
+- **CI**: リポジトリ全体の lint / typecheck / build / DB を含む検証を最終保証とする。
+
+## 進め方の規約
+
+- 返答・レビューコメント・PR 本文・コミット本文は日本語。
+- まず既存実装と既存差分を確認し、前提を決め打ちしない。**ユーザーの未コミット差分は勝手に戻さない。**
+- 破壊的コマンドは明示的な依頼・承認がある場合のみ実行。
+- 変更は必要最小限にとどめ、unrelated な修正を混ぜない。frontend / backend / docs をまたぐ変更は理由を説明する。
+- 実装後は可能な範囲でテスト・型チェック・ビルドを実行し、単体テストを追加する (カバレッジ 80% 以上が目標)。実行できなかった検証・既存不具合による失敗は明記する。
+
+## Issue / PR / Review
+
+- **Issue**: `Summary` `Background` `Scope` `Acceptance Criteria` を必須。実装しない範囲は `Out of Scope` / `Notes`、確認手順は `Verification` に記す。
+- **PR**: `Summary` と `Verification` を必須。影響が広い場合は `Risks` / `Notes`。hook や CI の既存失敗は今回変更と切り分けて書く。
+- **Review**: findings first。severity を意識し根拠ファイルを示す。問題がなければ「追加指摘なし」と明示。推測はその旨を明記する。

--- a/README.md
+++ b/README.md
@@ -2,121 +2,6 @@
 
 このプロジェクトは、モノレポ構成（frontend / backend / docs）で構築されたクエスト投稿・参加アプリです。
 
-## プロダクト概要
-
-クエスト掲示板は、ユーザーがクエストを投稿し、参加し、レビューできるアプリです。
-
-主なユースケース:
-
-- クエスト一覧の閲覧
-- クエスト詳細の確認
-- クエストの作成、編集、削除
-- クエストへの参加
-- レビュー投稿
-- マイページでの自分の活動確認
-- 管理者によるユーザー管理
-
-主要なデータフロー:
-
-```text
-ブラウザ
-  -> apps/frontend (Next.js)
-  -> apps/backend (Express API)
-  -> Prisma
-  -> MySQL
-
-認証:
-Firebase Authentication
-  -> frontend でログイン状態を管理
-  -> backend でトークンを検証
-```
-
-## リポジトリ全体像
-
-AI エージェントはまず次の単位でリポジトリを見ると全体像を把握しやすいです。
-
-```text
-repo
-├─ apps
-│  ├─ frontend   # UI、画面、hooks、API client
-│  ├─ backend    # API、service、Prisma、認証
-│  ├─ docs       # 開発ドキュメントサイト
-│  └─ e2e        # Playwright E2E テスト
-<<<<<<< HEAD
-├─ docs          # AI / 開発運用の正本ドキュメント
-├─ prompt        # 補助テンプレート
-├─ AGENTS.md     # AI 共通ルールの正本
-├─ CLAUDE.md     # 互換用の案内
-└─ README.md     # セットアップと repo 全体像
-=======
-├─ packages
-│  └─ types      # 共有型
-├─ docs          # AI / 開発運用の正本ドキュメント
-├─ prompt        # エージェント用テンプレート
-├─ AGENTS.md     # AI 共通ルール
-└─ README.md     # セットアップと全体像
->>>>>>> origin/main
-```
-
-## 変更箇所の当たり方
-
-変更内容ごとの主な確認先:
-
-| 変更内容 | 主な確認先 |
-|--------|------|
-| 画面、導線、表示 | `apps/frontend/src/app`, `apps/frontend/src/components` |
-| API 呼び出し | `apps/frontend/src/services` |
-| 認証 | `apps/frontend/src/hooks`, `apps/frontend/src/services/firebase.ts`, `apps/backend/src/middlewares/auth.middleware.ts` |
-| API 追加、修正 | `apps/backend/src/routes`, `apps/backend/src/controllers`, `apps/backend/src/services` |
-| DB 変更 | `apps/backend/prisma/schema.prisma`, `apps/backend/src/dataAccessor` |
-| テスト | `apps/frontend/src/__tests__`, `apps/backend/src/__tests__`, `apps/e2e/tests` |
-| ルール、設計 | `AGENTS.md`, `docs/architecture.md`, `docs/ai-execution.md` |
-
-<<<<<<< HEAD
-## AI 向けドキュメント導線
-
-AI が最初に読むべき文書セットは次の 5 つです。
-=======
-## AI向けドキュメント導線
-
-AIエージェント向けの正本は以下です。
->>>>>>> origin/main
-
-1. `README.md`
-2. `AGENTS.md`
-3. `docs/architecture.md`
-4. `docs/ai-execution.md`
-5. `prompt/agent.md`
-<<<<<<< HEAD
-6. 関連コード / 関連テスト
-=======
-6. 関連コード / テスト
->>>>>>> origin/main
-
-役割は次のとおりです。
-
-- `README.md`: セットアップ、開発コマンド、リポジトリ全体像
-<<<<<<< HEAD
-- `AGENTS.md`: AI エージェント共通ルールの正本
-- `docs/architecture.md`: repo 構造、レイヤー責務、変更判断の基準
-- `docs/ai-execution.md`: 調査、実装、検証、報告の進め方
-- `prompt/agent.md`: 他エージェントに渡す短い実行テンプレート
-
-補助テンプレートは source-of-truth ではありません。
-
-- `prompt/create_issue.md`: 改善 issue を新規起票するときの補助テンプレート
-- `prompt/modify_issue.md`: 既存 issue を整理、修正するときの補助テンプレート
-- `CLAUDE.md`: `AGENTS.md` への互換エントリ
-=======
-- `AGENTS.md`: AIエージェント共通ルール
-- `docs/architecture.md`: 実装対象の構造、責務、変更時の判断基準
-- `docs/ai-execution.md`: AIの調査、実装、検証フロー
-- `prompt/agent.md`: 他エージェントにも渡せる実行テンプレート
-- `prompt/create_issue.md`: 改善 issue を新規起票するときの補助プロンプト
-- `prompt/modify_issue.md`: 既存 issue を整理、修正するときの補助プロンプト
-- `ai-docs-refactor-prompt.md`: AI 向け docs 自体を見直すときの補助プロンプト
->>>>>>> origin/main
-
 ---
 
 ## 技術スタック
@@ -153,7 +38,7 @@ npm install -g pnpm
 ### 1. リポジトリをクローン
 
 ```bash
-git clone https://github.com/Numamura-dev/quest-board-app.git
+git clone https://github.com/natsumi-a98/quest-board-app.git
 cd quest-board-app
 ```
 
@@ -191,6 +76,7 @@ cp apps/backend/.env.local.example apps/backend/.env.local
 ```
 
 `apps/backend/.env.local` を開き、各項目を設定してください。
+
 ```env
 # Firebase Admin SDK（Firebase コンソール > プロジェクトの設定 > サービスアカウント から取得）
 FIREBASE_PROJECT_ID=your-project-id
@@ -283,7 +169,6 @@ pnpm dev:docs
 | `pnpm build` | 全サービスをビルド |
 | `pnpm lint` | Biome でコードをチェック |
 | `pnpm lint:fix` | Biome で自動修正 |
-| `pnpm openapi:diff-to-zod -- --base <base-openapi.json> --head <head-openapi.json> [--out <output.ts>]` | OpenAPI 差分から zod schema の叩き台を生成 |
 | `pnpm db:generate` | Prisma クライアントを生成 |
 | `pnpm db:push` | スキーマをDBに反映 |
 | `pnpm db:studio` | Prisma Studio（DB GUI）を起動 |
@@ -300,6 +185,18 @@ pnpm dev:docs
 
 ---
 
+## ドキュメントサイト
+
+プロジェクトの設計資料・規約は VitePress サイトとして `apps/docs/` にまとまっています。
+
+```bash
+pnpm dev:docs   # http://localhost:5173 で確認
+```
+
+主なコンテンツ: スタイルガイド / コーディング規約 / API 一覧 / ディレクトリ構成（FE・BE）/ 要件定義書 / テーブル定義書 / レビュー規約 / ログ設計書
+
+---
+
 ## API ドキュメント
 
 バックエンド起動後、以下で OpenAPI を確認できます。
@@ -308,21 +205,6 @@ pnpm dev:docs
 - OpenAPI JSON: `http://localhost:3001/api/openapi.json`
 
 現在の request schema は backend の `zod` を source of truth とし、OpenAPI ドキュメントも同じ schema から生成します。新しい API を追加する場合は、controller に手書きの `if` を足すのではなく、`apps/backend/src/schemas/api.ts` に schema を追加して `validateRequest` から利用してください。
-
-API path は REST の原則に沿って設計します。動詞を path に埋め込むより、resource と HTTP method で意味を表現してください。
-
-例:
-- `POST /api/users/create` ではなく `POST /api/users`
-- `GET /api/users/all` ではなく `GET /api/users`
-- `POST /api/quests/:questId/join` ではなく `POST /api/quests/:questId/participants`
-- `GET /api/reviews/quest/:questId` ではなく `GET /api/quests/:questId/reviews`
-- `POST /api/quests/:id/restore` のような状態遷移も、可能なら `restorations` `activations` のような resource 名で表現する
-
-既存 OpenAPI の差分から zod schema の叩き台を作る場合は、次のコマンドを使います。
-
-```bash
-pnpm openapi:diff-to-zod -- --base <base-openapi.json> --head <head-openapi.json> [--out <output.ts>]
-```
 
 VS Code では `.vscode/extensions.json` に OpenAPI 向けの推奨拡張を追加しています。workspace を開くと推奨が表示されます。
 

--- a/apps/backend/.env.local.example
+++ b/apps/backend/.env.local.example
@@ -5,6 +5,9 @@ FIREBASE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\nYOUR_PRIVATE_KEY_HERE\n-----E
 
 # Prisma / MySQL（docker-compose.yml のデフォルト値に合わせる）
 DATABASE_URL=mysql://app_user:app_password@localhost:3306/your_project_db
+# SHADOW_DATABASE_URL は pnpm db:push 時に Prisma がスキーマ差分検出に使う一時 DB。
+# root ユーザーで接続することで Prisma が自動作成する。DB 名は本体と別にする。
+SHADOW_DATABASE_URL=mysql://root:rootpassword@localhost:3306/shadow_your_project_db
 MYSQL_ROOT_PASSWORD=rootpassword
 MYSQL_DATABASE=your_project_db
 MYSQL_USER=app_user


### PR DESCRIPTION
## Summary

- AGENTS.md: AI エージェント向けの実行ガイドラインを整理（層構造・エラーハンドリング・認証フローなど）
- CLAUDE.md: コマンド一覧・アーキテクチャ・進め方の規約を最新状態に更新
- README.md: セットアップ手順と AI ドキュメントへの入口を整備
- .gitignore: `**/.DS_Store` 再帰パターンに変更・E2E 出力ディレクトリを追加
- `.env.local.example`: コメントと環境変数説明を追加

**#323 の代替 PR**。#323 は実装コミット（OpenAPI/zod 等）との競合解消時に大量の変更が混入し 154 ファイル/ +10883 行となっていたため、docs ファイル 5 件のみを `origin/main` から clean に切り出して再作成した。

## Verification

- `changedFiles` が 5 件のみであることを確認
- `AGENTS.md` / `CLAUDE.md` の内容が最新の規約を反映していることを確認
- `README.md` のセットアップ手順が README と一致していることを確認