### PR TITLE
エラーハンドリングを統一

### DIFF
--- a/apps/backend/src/__tests__/controllers/questJoinController.test.ts
+++ b/apps/backend/src/__tests__/controllers/questJoinController.test.ts
@@ -1,0 +1,82 @@
+import type { NextFunction, Request, Response } from "express";
+import { joinQuest } from "../../controllers/questJoinController";
+import { addUserToQuest } from "../../services/questJoinService";
+import { getUserByGoogleSubService } from "../../services/userService";
+import type { AppError } from "../../utils/appError";
+import { validateRequest } from "../../utils/validate";
+
+jest.mock("../../utils/validate", () => ({
+	validateRequest: jest.fn(),
+}));
+
+jest.mock("../../services/questJoinService", () => ({
+	addUserToQuest: jest.fn(),
+}));
+
+jest.mock("../../services/userService", () => ({
+	getUserByGoogleSubService: jest.fn(),
+}));
+
+const mockValidateRequest = validateRequest as jest.MockedFunction<
+	typeof validateRequest
+>;
+const mockAddUserToQuest = addUserToQuest as jest.MockedFunction<
+	typeof addUserToQuest
+>;
+const mockGetUserByGoogleSubService =
+	getUserByGoogleSubService as jest.MockedFunction<
+		typeof getUserByGoogleSubService
+	>;
+
+const createResponse = () =>
+	({
+		json: jest.fn(),
+	}) as unknown as Response;
+
+const waitForAsyncHandler = () =>
+	new Promise<void>((resolve) => {
+		setImmediate(() => resolve());
+	});
+
+describe("questJoinController", () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockValidateRequest.mockReturnValue({
+			params: { questId: 1 },
+			body: {},
+			query: {},
+		} as never);
+		mockGetUserByGoogleSubService.mockResolvedValue({
+			id: 10,
+		} as never);
+	});
+
+	it.each([
+		["duplicate", 409, "CONFLICT"],
+		["full", 409, "CONFLICT"],
+		["not_found", 404, "NOT_FOUND"],
+		["error", 400, "VALIDATION_ERROR"],
+	])(
+		"参加失敗 reason %s を標準 AppError に変換する",
+		async (reason, statusCode, code) => {
+			mockAddUserToQuest.mockResolvedValueOnce({
+				success: false,
+				reason,
+			} as never);
+
+			const req = { user: { sub: "google-sub-10" } } as unknown as Request;
+			const res = createResponse();
+			const next = jest.fn();
+
+			joinQuest(req, res, next as unknown as NextFunction);
+			await waitForAsyncHandler();
+
+			expect(next).toHaveBeenCalled();
+			expect(next.mock.calls[0][0]).toMatchObject({
+				name: "AppError",
+				statusCode,
+				code,
+			} satisfies Partial<AppError>);
+		},
+	);
+});

--- a/apps/backend/src/__tests__/controllers/reviewController.test.ts
+++ b/apps/backend/src/__tests__/controllers/reviewController.test.ts
@@ -96,6 +96,38 @@ describe("reviewController", () => {
 		expect(next).not.toHaveBeenCalled();
 	});
 
+	it("createReview は重複レビューの AppError をそのまま next へ渡す", async () => {
+		mockValidateRequest.mockReturnValue({
+			params: { questId: 1 },
+			body: { rating: 5, comment: "test" },
+			query: {},
+		} as never);
+		mockGetUserByGoogleSubService.mockResolvedValueOnce({
+			id: 10,
+			role: ROLES.USER,
+		} as never);
+		mockCreateReviewService.mockRejectedValueOnce(
+			new AppError(
+				"このクエストには既にレビューを投稿済みです。",
+				409,
+				"CONFLICT",
+			) as never,
+		);
+
+		const req = { user: { sub: "google-sub-10" } } as unknown as Request;
+		const res = createResponse();
+		const next = jest.fn();
+
+		createReview(req, res, next as unknown as NextFunction);
+		await waitForAsyncHandler();
+
+		expect(next).toHaveBeenCalled();
+		const error = next.mock.calls[0][0] as AppError;
+		expect(error).toBeInstanceOf(AppError);
+		expect(error.statusCode).toBe(409);
+		expect(error.code).toBe("CONFLICT");
+	});
+
 	it("updateReview はレビュー所有者以外の更新を 403 で拒否する", async () => {
 		mockValidateRequest.mockReturnValue({
 			params: { reviewId: 1 },

--- a/apps/backend/src/__tests__/services/adminUserService.test.ts
+++ b/apps/backend/src/__tests__/services/adminUserService.test.ts
@@ -1,34 +1,69 @@
 // adminUserService.test.ts
-import { getAllUsersForAdminService } from "../../services/adminUserService";
+import {
+	getAllUsersForAdminService,
+	updateUserRoleService,
+} from "../../services/adminUserService";
+import type { AppError } from "../../utils/appError";
 
 // UserDataAccessor をモック化
 jest.mock("@/dataAccessor/dbAccessor/User", () => {
-  // require で遅延読み込み
-  const { mockUserDataAccessor } = require("../mocks/UserDataAccessor.mock");
-  return {
-    UserDataAccessor: jest.fn().mockImplementation(() => mockUserDataAccessor),
-  };
+	// require で遅延読み込み
+	const { mockUserDataAccessor } = require("../mocks/UserDataAccessor.mock");
+	return {
+		UserDataAccessor: jest.fn().mockImplementation(() => mockUserDataAccessor),
+	};
 });
 
 describe("getAllUsersForAdminService", () => {
-  const { mockUserDataAccessor, mockAllUsersForAdmin } = require("../mocks/UserDataAccessor.mock");
+	const {
+		mockUserDataAccessor,
+		mockAllUsersForAdmin,
+	} = require("../mocks/UserDataAccessor.mock");
 
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
 
-  it("全ユーザーを取得できる", async () => {
-    mockUserDataAccessor.getAllForAdmin.mockResolvedValue(mockAllUsersForAdmin);
+	it("全ユーザーを取得できる", async () => {
+		mockUserDataAccessor.getAllForAdmin.mockResolvedValue(mockAllUsersForAdmin);
 
-    const users = await getAllUsersForAdminService();
+		const users = await getAllUsersForAdminService();
 
-    expect(mockUserDataAccessor.getAllForAdmin).toHaveBeenCalledTimes(1);
-    expect(users).toEqual(mockAllUsersForAdmin);
-  });
+		expect(mockUserDataAccessor.getAllForAdmin).toHaveBeenCalledTimes(1);
+		expect(users).toEqual(mockAllUsersForAdmin);
+	});
 
-  it("エラーが発生した場合は例外を投げる", async () => {
-    mockUserDataAccessor.getAllForAdmin.mockRejectedValue(new Error("DB Error"));
+	it("エラーが発生した場合は例外を投げる", async () => {
+		mockUserDataAccessor.getAllForAdmin.mockRejectedValue(
+			new Error("DB Error"),
+		);
 
-    await expect(getAllUsersForAdminService()).rejects.toThrow("DB Error");
-  });
+		await expect(getAllUsersForAdminService()).rejects.toThrow("DB Error");
+	});
+});
+
+describe("updateUserRoleService", () => {
+	const { mockUserDataAccessor } = require("../mocks/UserDataAccessor.mock");
+
+	beforeEach(() => {
+		jest.clearAllMocks();
+	});
+
+	it("不正なロールは VALIDATION_ERROR を投げる", async () => {
+		await expect(updateUserRoleService(1, "owner")).rejects.toMatchObject({
+			name: "AppError",
+			statusCode: 400,
+			code: "VALIDATION_ERROR",
+		} satisfies Partial<AppError>);
+	});
+
+	it("存在しないユーザーは NOT_FOUND を投げる", async () => {
+		mockUserDataAccessor.findById.mockResolvedValueOnce(null);
+
+		await expect(updateUserRoleService(999, "user")).rejects.toMatchObject({
+			name: "AppError",
+			statusCode: 404,
+			code: "NOT_FOUND",
+		} satisfies Partial<AppError>);
+	});
 });

--- a/apps/backend/src/controllers/adminUserController.ts
+++ b/apps/backend/src/controllers/adminUserController.ts
@@ -7,7 +7,6 @@ import {
 	getAllUsersForAdminService,
 	updateUserRoleService,
 } from "../services/adminUserService";
-import { notFound } from "../utils/appError";
 import { asyncHandler } from "../utils/asyncHandler";
 import { validateRequest } from "../utils/validate";
 
@@ -33,16 +32,7 @@ export const updateUserRole = asyncHandler(
 		const { userId } = params;
 		const { role } = body;
 
-		let updatedUser: Awaited<ReturnType<typeof updateUserRoleService>>;
-		try {
-			updatedUser = await updateUserRoleService(userId, role);
-		} catch (error) {
-			if (error instanceof Error && error.message === "User not found") {
-				throw notFound(error.message);
-			}
-
-			throw error;
-		}
+		const updatedUser = await updateUserRoleService(userId, role);
 
 		res.json({
 			message: "ユーザーのロールが正常に更新されました",

--- a/apps/backend/src/controllers/questJoinController.ts
+++ b/apps/backend/src/controllers/questJoinController.ts
@@ -2,7 +2,12 @@ import type { Request, Response } from "express";
 import { QuestJoinParamSchema } from "../schemas/api";
 import { addUserToQuest } from "../services/questJoinService";
 import { getUserByGoogleSubService } from "../services/userService";
-import { badRequest, notFound, unauthorized } from "../utils/appError";
+import {
+	badRequest,
+	conflict,
+	notFound,
+	unauthorized,
+} from "../utils/appError";
 import { asyncHandler } from "../utils/asyncHandler";
 import { validateRequest } from "../utils/validate";
 
@@ -25,16 +30,17 @@ export const joinQuest = asyncHandler(async (req: Request, res: Response) => {
 
 	const result = await addUserToQuest(user.id, questId);
 	if (!result || !result.success) {
-		const errorMessage =
-			result?.reason === "duplicate"
-				? "既に参加しています"
-				: result?.reason === "full"
-					? "参加人数が上限に達しています"
-					: result?.reason === "not_found"
-						? "クエストが見つかりません"
-						: "参加に失敗しました";
+		if (result?.reason === "duplicate") {
+			throw conflict("既に参加しています");
+		}
+		if (result?.reason === "full") {
+			throw conflict("参加人数が上限に達しています");
+		}
+		if (result?.reason === "not_found") {
+			throw notFound("クエストが見つかりません");
+		}
 
-		throw badRequest(errorMessage);
+		throw badRequest("参加に失敗しました");
 	}
 
 	res.json({ success: true, message: "クエストに参加しました！" });

--- a/apps/backend/src/controllers/reviewController.ts
+++ b/apps/backend/src/controllers/reviewController.ts
@@ -17,12 +17,7 @@ import {
 	updateReviewService,
 } from "../services/reviewService";
 import { getUserByGoogleSubService } from "../services/userService";
-import {
-	badRequest,
-	forbidden,
-	notFound,
-	unauthorized,
-} from "../utils/appError";
+import { forbidden, notFound, unauthorized } from "../utils/appError";
 import { asyncHandler } from "../utils/asyncHandler";
 import { validateRequest } from "../utils/validate";
 
@@ -66,25 +61,14 @@ export const createReview = asyncHandler(
 		const { questId } = params;
 		const { rating, comment } = body;
 
-		try {
-			const review = await createReviewService({
-				questId,
-				reviewer_id: currentUser.id,
-				rating,
-				comment,
-			});
+		const review = await createReviewService({
+			questId,
+			reviewer_id: currentUser.id,
+			rating,
+			comment,
+		});
 
-			res.status(201).json(review);
-		} catch (error) {
-			if (
-				error instanceof Error &&
-				error.message.includes("既にレビューを投稿済み")
-			) {
-				throw badRequest(error.message);
-			}
-
-			throw error;
-		}
+		res.status(201).json(review);
 	},
 );
 

--- a/apps/backend/src/services/adminUserService.ts
+++ b/apps/backend/src/services/adminUserService.ts
@@ -1,6 +1,7 @@
-import { UserDataAccessor } from "../dataAccessor/dbAccessor/User";
-import { VALID_ROLES } from "../constants/roles";
 import { logger } from "../config/logger";
+import { VALID_ROLES } from "../constants/roles";
+import { UserDataAccessor } from "../dataAccessor/dbAccessor/User";
+import { badRequest, notFound } from "../utils/appError";
 
 const userDataAccessor = new UserDataAccessor();
 
@@ -9,7 +10,7 @@ const userDataAccessor = new UserDataAccessor();
  * @returns 管理者向けユーザー一覧
  */
 export const getAllUsersForAdminService = async () => {
-  return await userDataAccessor.getAllForAdmin();
+	return await userDataAccessor.getAllForAdmin();
 };
 
 /**
@@ -19,28 +20,28 @@ export const getAllUsersForAdminService = async () => {
  * @returns 更新後のユーザー情報
  */
 export const updateUserRoleService = async (
-  userId: number,
-  newRole: string
+	userId: number,
+	newRole: string,
 ) => {
-  try {
-    // 有効なロールかチェック
-    if (!VALID_ROLES.includes(newRole as (typeof VALID_ROLES)[number])) {
-      throw new Error("Invalid role. Must be 'admin' or 'user'");
-    }
+	try {
+		// 有効なロールかチェック
+		if (!VALID_ROLES.includes(newRole as (typeof VALID_ROLES)[number])) {
+			throw badRequest("Invalid role. Must be 'admin' or 'user'");
+		}
 
-    // ユーザーが存在するかチェック
-    const existingUser = await userDataAccessor.findById(userId);
-    if (!existingUser) {
-      throw new Error("User not found");
-    }
+		// ユーザーが存在するかチェック
+		const existingUser = await userDataAccessor.findById(userId);
+		if (!existingUser) {
+			throw notFound("User not found");
+		}
 
-    // ロールを更新
-    const updatedUser = await userDataAccessor.update(userId, {
-      role: newRole,
-    });
-    return updatedUser;
-  } catch (error) {
-    logger.error({ err: error, userId, newRole }, "ユーザーロール更新エラー");
-    throw error;
-  }
+		// ロールを更新
+		const updatedUser = await userDataAccessor.update(userId, {
+			role: newRole,
+		});
+		return updatedUser;
+	} catch (error) {
+		logger.error({ err: error, userId, newRole }, "ユーザーロール更新エラー");
+		throw error;
+	}
 };

--- a/apps/backend/src/services/reviewService.ts
+++ b/apps/backend/src/services/reviewService.ts
@@ -4,6 +4,7 @@ import {
 	ReviewDataAccessor,
 	type UpdateReviewData,
 } from "../dataAccessor/dbAccessor";
+import { conflict } from "../utils/appError";
 
 const reviewDataAccessor = new ReviewDataAccessor();
 
@@ -41,7 +42,7 @@ export const createReviewService = async (data: CreateReviewData) => {
 		);
 
 		if (existingReview) {
-			throw new Error("このクエストには既にレビューを投稿済みです。");
+			throw conflict("このクエストには既にレビューを投稿済みです。");
 		}
 
 		const review = await reviewDataAccessor.create(data);

--- a/apps/frontend/src/__tests__/components/organisms/QuestEditorForm.test.tsx
+++ b/apps/frontend/src/__tests__/components/organisms/QuestEditorForm.test.tsx
@@ -1,171 +1,222 @@
-import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { QuestEditorForm } from "@/components/organisms/QuestEditorForm";
 import {
-  DEFAULT_QUEST_FORM_DATA,
-  applyMarkdownFormat,
-  validateQuestForm,
+	DEFAULT_QUEST_FORM_DATA,
+	applyMarkdownFormat,
+	validateQuestForm,
 } from "@/components/organisms/questEditorUtils";
+import { ApiError } from "@/services/apiError";
+import {
+	act,
+	fireEvent,
+	render,
+	screen,
+	waitFor,
+} from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 describe("QuestEditorForm", () => {
-  beforeEach(() => {
-    window.localStorage.clear();
-  });
+	beforeEach(() => {
+		window.localStorage.clear();
+	});
 
-  it("必須項目が空のときにバリデーションエラーを表示する", async () => {
-    const onSubmit = vi.fn().mockResolvedValue(undefined);
+	it("必須項目が空のときにバリデーションエラーを表示する", async () => {
+		const onSubmit = vi.fn().mockResolvedValue(undefined);
 
-    render(
-      <QuestEditorForm
-        title="新しいクエストを作成"
-        submitLabel="クエストを作成"
-        submittingLabel="作成中..."
-        draftStorageKey="quest-editor:test-required"
-        onSubmit={onSubmit}
-        onClose={vi.fn()}
-      />
-    );
+		render(
+			<QuestEditorForm
+				title="新しいクエストを作成"
+				submitLabel="クエストを作成"
+				submittingLabel="作成中..."
+				draftStorageKey="quest-editor:test-required"
+				onSubmit={onSubmit}
+				onClose={vi.fn()}
+			/>,
+		);
 
-    fireEvent.click(screen.getAllByRole("button", { name: "クエストを作成" })[0]);
+		fireEvent.click(
+			screen.getAllByRole("button", { name: "クエストを作成" })[0],
+		);
 
-    expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
-    expect(screen.getByText("説明は必須です")).toBeInTheDocument();
-    expect(screen.getByText("開始日は必須です")).toBeInTheDocument();
-    expect(screen.getByText("終了日は必須です")).toBeInTheDocument();
-    expect(onSubmit).not.toHaveBeenCalled();
-  });
+		expect(await screen.findByText("タイトルは必須です")).toBeInTheDocument();
+		expect(screen.getByText("説明は必須です")).toBeInTheDocument();
+		expect(screen.getByText("開始日は必須です")).toBeInTheDocument();
+		expect(screen.getByText("終了日は必須です")).toBeInTheDocument();
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
 
-  it("Markdown ツールバーで見出し記法を挿入できる", () => {
-    render(
-      <QuestEditorForm
-        title="新しいクエストを作成"
-        submitLabel="クエストを作成"
-        submittingLabel="作成中..."
-        draftStorageKey="quest-editor:test-markdown"
-        onSubmit={vi.fn().mockResolvedValue(undefined)}
-        onClose={vi.fn()}
-      />
-    );
+	it("Markdown ツールバーで見出し記法を挿入できる", () => {
+		render(
+			<QuestEditorForm
+				title="新しいクエストを作成"
+				submitLabel="クエストを作成"
+				submittingLabel="作成中..."
+				draftStorageKey="quest-editor:test-markdown"
+				onSubmit={vi.fn().mockResolvedValue(undefined)}
+				onClose={vi.fn()}
+			/>,
+		);
 
-    const textarea = screen.getByLabelText("説明 *") as HTMLTextAreaElement;
-    fireEvent.change(textarea, { target: { value: "本文" } });
-    textarea.setSelectionRange(0, 2);
+		const textarea = screen.getByLabelText("説明 *") as HTMLTextAreaElement;
+		fireEvent.change(textarea, { target: { value: "本文" } });
+		textarea.setSelectionRange(0, 2);
 
-    fireEvent.click(screen.getByRole("button", { name: /見出し/ }));
+		fireEvent.click(screen.getByRole("button", { name: /見出し/ }));
 
-    expect(textarea.value).toContain("## 本文");
-  });
+		expect(textarea.value).toContain("## 本文");
+	});
 
-  it("リンク挿入時に編集前提のプレースホルダーを使う", () => {
-    const result = applyMarkdownFormat("詳細はこちら", 0, 0, "link");
+	it("リンク挿入時に編集前提のプレースホルダーを使う", () => {
+		const result = applyMarkdownFormat("詳細はこちら", 0, 0, "link");
 
-    expect(result.nextValue).toContain("[リンクテキスト](https://)");
-  });
+		expect(result.nextValue).toContain("[リンクテキスト](https://)");
+	});
 
-  it("貼り付け時に不要な書式を除去する", () => {
-    render(
-      <QuestEditorForm
-        title="新しいクエストを作成"
-        submitLabel="クエストを作成"
-        submittingLabel="作成中..."
-        draftStorageKey="quest-editor:test-paste"
-        onSubmit={vi.fn().mockResolvedValue(undefined)}
-        onClose={vi.fn()}
-      />
-    );
+	it("貼り付け時に不要な書式を除去する", () => {
+		render(
+			<QuestEditorForm
+				title="新しいクエストを作成"
+				submitLabel="クエストを作成"
+				submittingLabel="作成中..."
+				draftStorageKey="quest-editor:test-paste"
+				onSubmit={vi.fn().mockResolvedValue(undefined)}
+				onClose={vi.fn()}
+			/>,
+		);
 
-    const textarea = screen.getByLabelText("説明 *") as HTMLTextAreaElement;
-    fireEvent.paste(textarea, {
-      clipboardData: {
-        getData: () => "• テスト\u200B\n\n\n次の行",
-      },
-    });
+		const textarea = screen.getByLabelText("説明 *") as HTMLTextAreaElement;
+		fireEvent.paste(textarea, {
+			clipboardData: {
+				getData: () => "• テスト\u200B\n\n\n次の行",
+			},
+		});
 
-    expect(textarea.value).toBe("- テスト\n\n次の行");
-  });
+		expect(textarea.value).toBe("- テスト\n\n次の行");
+	});
 
-  it("保存済みの下書きを復元し、送信中はボタンを無効化する", async () => {
-    window.localStorage.setItem(
-      "quest-editor:test-draft",
-      JSON.stringify({
-        ...DEFAULT_QUEST_FORM_DATA,
-        title: "保存済みタイトル",
-        description: "保存済み本文",
-        start_date: "2026-03-01",
-        end_date: "2026-03-10",
-      })
-    );
+	it("保存済みの下書きを復元し、送信中はボタンを無効化する", async () => {
+		window.localStorage.setItem(
+			"quest-editor:test-draft",
+			JSON.stringify({
+				...DEFAULT_QUEST_FORM_DATA,
+				title: "保存済みタイトル",
+				description: "保存済み本文",
+				start_date: "2026-03-01",
+				end_date: "2026-03-10",
+			}),
+		);
 
-    let resolveSubmit: (() => void) | undefined;
-    const onSubmit = vi.fn(
-      () =>
-        new Promise<void>((resolve) => {
-          resolveSubmit = resolve;
-        })
-    );
+		let resolveSubmit: (() => void) | undefined;
+		const onSubmit = vi.fn(
+			() =>
+				new Promise<void>((resolve) => {
+					resolveSubmit = resolve;
+				}),
+		);
 
-    render(
-      <QuestEditorForm
-        title="新しいクエストを作成"
-        submitLabel="クエストを作成"
-        submittingLabel="作成中..."
-        draftStorageKey="quest-editor:test-draft"
-        onSubmit={onSubmit}
-        onClose={vi.fn()}
-      />
-    );
+		render(
+			<QuestEditorForm
+				title="新しいクエストを作成"
+				submitLabel="クエストを作成"
+				submittingLabel="作成中..."
+				draftStorageKey="quest-editor:test-draft"
+				onSubmit={onSubmit}
+				onClose={vi.fn()}
+			/>,
+		);
 
-    expect(await screen.findByDisplayValue("保存済みタイトル")).toBeInTheDocument();
-    expect(screen.getByText("保存されていた下書きを復元しました。")).toBeInTheDocument();
+		expect(
+			await screen.findByDisplayValue("保存済みタイトル"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("保存されていた下書きを復元しました。"),
+		).toBeInTheDocument();
 
-    fireEvent.click(screen.getAllByRole("button", { name: "クエストを作成" })[0]);
+		fireEvent.click(
+			screen.getAllByRole("button", { name: "クエストを作成" })[0],
+		);
 
-    await waitFor(() => {
-      expect(onSubmit).toHaveBeenCalledTimes(1);
-      expect(
-        screen.getAllByRole("button", { name: "作成中..." })[0]
-      ).toBeDisabled();
-    });
+		await waitFor(() => {
+			expect(onSubmit).toHaveBeenCalledTimes(1);
+			expect(
+				screen.getAllByRole("button", { name: "作成中..." })[0],
+			).toBeDisabled();
+		});
 
-    await act(async () => {
-      resolveSubmit?.();
-    });
-  });
+		await act(async () => {
+			resolveSubmit?.();
+		});
+	});
 
-  it("保存済み下書きがなくても入力内容を自動保存する", async () => {
-    render(
-      <QuestEditorForm
-        title="新しいクエストを作成"
-        submitLabel="クエストを作成"
-        submittingLabel="作成中..."
-        draftStorageKey="quest-editor:test-autosave"
-        onSubmit={vi.fn().mockResolvedValue(undefined)}
-        onClose={vi.fn()}
-      />
-    );
+	it("保存済み下書きがなくても入力内容を自動保存する", async () => {
+		render(
+			<QuestEditorForm
+				title="新しいクエストを作成"
+				submitLabel="クエストを作成"
+				submittingLabel="作成中..."
+				draftStorageKey="quest-editor:test-autosave"
+				onSubmit={vi.fn().mockResolvedValue(undefined)}
+				onClose={vi.fn()}
+			/>,
+		);
 
-    fireEvent.change(screen.getByLabelText("タイトル *"), {
-      target: { value: "新規タイトル" },
-    });
+		fireEvent.change(screen.getByLabelText("タイトル *"), {
+			target: { value: "新規タイトル" },
+		});
 
-    await waitFor(() => {
-      expect(
-        JSON.parse(
-          window.localStorage.getItem("quest-editor:test-autosave") ?? "{}"
-        ).title
-      ).toBe("新規タイトル");
-    });
-  });
+		await waitFor(() => {
+			expect(
+				JSON.parse(
+					window.localStorage.getItem("quest-editor:test-autosave") ?? "{}",
+				).title,
+			).toBe("新規タイトル");
+		});
+	});
 
-  it("終了日が開始日より前ならバリデーションエラーを返す", () => {
-    const errors = validateQuestForm({
-      ...DEFAULT_QUEST_FORM_DATA,
-      title: "クエスト",
-      description: "説明",
-      start_date: "2026-03-10",
-      end_date: "2026-03-01",
-    });
+	it("終了日が開始日より前ならバリデーションエラーを返す", () => {
+		const errors = validateQuestForm({
+			...DEFAULT_QUEST_FORM_DATA,
+			title: "クエスト",
+			description: "説明",
+			start_date: "2026-03-10",
+			end_date: "2026-03-01",
+		});
 
-    expect(errors.end_date).toBe("終了日は開始日以降を指定してください");
-  });
+		expect(errors.end_date).toBe("終了日は開始日以降を指定してください");
+	});
+
+	it("API validation details を該当フィールドに表示する", async () => {
+		const onSubmit = vi
+			.fn()
+			.mockRejectedValue(
+				new ApiError("Invalid", "VALIDATION_ERROR", 400, [
+					{ field: "title", message: "タイトルは既に使われています" },
+				]),
+			);
+
+		render(
+			<QuestEditorForm
+				title="新しいクエストを作成"
+				submitLabel="クエストを作成"
+				submittingLabel="作成中..."
+				draftStorageKey="quest-editor:test-api-errors"
+				initialData={{
+					...DEFAULT_QUEST_FORM_DATA,
+					title: "既存タイトル",
+					description: "説明",
+					start_date: "2026-03-01",
+					end_date: "2026-03-10",
+				}}
+				onSubmit={onSubmit}
+				onClose={vi.fn()}
+			/>,
+		);
+
+		fireEvent.click(
+			screen.getAllByRole("button", { name: "クエストを作成" })[0],
+		);
+
+		expect(
+			await screen.findByText("タイトルは既に使われています"),
+		).toBeInTheDocument();
+	});
 });

--- a/apps/frontend/src/__tests__/components/providers/ToastProvider.test.tsx
+++ b/apps/frontend/src/__tests__/components/providers/ToastProvider.test.tsx
@@ -1,0 +1,64 @@
+import { ToastProvider, useToast } from "@/components/providers/ToastProvider";
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+const ToastTrigger = () => {
+	const { showToast } = useToast();
+	return (
+		<>
+			<button
+				type="button"
+				onClick={() => showToast("保存しました。", "success")}
+			>
+				success
+			</button>
+			<button
+				type="button"
+				onClick={() => showToast("失敗しました。", "error")}
+			>
+				error
+			</button>
+		</>
+	);
+};
+
+describe("ToastProvider", () => {
+	it("複数 toast を表示し、dismiss できる", () => {
+		render(
+			<ToastProvider>
+				<ToastTrigger />
+			</ToastProvider>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "success" }));
+		fireEvent.click(screen.getByRole("button", { name: "error" }));
+
+		expect(screen.getByText("保存しました。")).toBeInTheDocument();
+		expect(screen.getByText("失敗しました。")).toBeInTheDocument();
+
+		fireEvent.click(screen.getAllByRole("button", { name: "通知を閉じる" })[0]);
+
+		expect(screen.queryByText("保存しました。")).toBeNull();
+		expect(screen.getByText("失敗しました。")).toBeInTheDocument();
+	});
+
+	it("一定時間後に自動で消える", () => {
+		vi.useFakeTimers();
+
+		render(
+			<ToastProvider>
+				<ToastTrigger />
+			</ToastProvider>,
+		);
+
+		fireEvent.click(screen.getByRole("button", { name: "success" }));
+		expect(screen.getByText("保存しました。")).toBeInTheDocument();
+
+		act(() => {
+			vi.advanceTimersByTime(4000);
+		});
+
+		expect(screen.queryByText("保存しました。")).toBeNull();
+		vi.useRealTimers();
+	});
+});

--- a/apps/frontend/src/__tests__/services/apiError.test.ts
+++ b/apps/frontend/src/__tests__/services/apiError.test.ts
@@ -1,110 +1,197 @@
-import { describe, it, expect } from "vitest";
-import { ApiError, isApiErrorResponse } from "@/services/apiError";
+import {
+	ApiError,
+	getUserFacingErrorMessage,
+	getValidationFieldErrors,
+	isApiErrorResponse,
+	isAuthRequiredError,
+} from "@/services/apiError";
+import { describe, expect, it } from "vitest";
 
 describe("ApiError", () => {
-  it("メッセージ・コード・ステータスが正しく設定される", () => {
-    const err = new ApiError("Not found", "NOT_FOUND", 404);
-    expect(err.message).toBe("Not found");
-    expect(err.code).toBe("NOT_FOUND");
-    expect(err.status).toBe(404);
-  });
+	it("メッセージ・コード・ステータスが正しく設定される", () => {
+		const err = new ApiError("Not found", "NOT_FOUND", 404);
+		expect(err.message).toBe("Not found");
+		expect(err.code).toBe("NOT_FOUND");
+		expect(err.status).toBe(404);
+	});
 
-  it("name が ApiError になる", () => {
-    const err = new ApiError("error", "CODE", 400);
-    expect(err.name).toBe("ApiError");
-  });
+	it("name が ApiError になる", () => {
+		const err = new ApiError("error", "CODE", 400);
+		expect(err.name).toBe("ApiError");
+	});
 
-  it("details が任意で設定される", () => {
-    const details = [{ field: "email", message: "invalid" }];
-    const err = new ApiError("Validation failed", "VALIDATION_ERROR", 400, details);
-    expect(err.details).toEqual(details);
-  });
+	it("details が任意で設定される", () => {
+		const details = [{ field: "email", message: "invalid" }];
+		const err = new ApiError(
+			"Validation failed",
+			"VALIDATION_ERROR",
+			400,
+			details,
+		);
+		expect(err.details).toEqual(details);
+	});
 
-  it("details なしの場合は undefined", () => {
-    const err = new ApiError("error", "CODE", 400);
-    expect(err.details).toBeUndefined();
-  });
+	it("details なしの場合は undefined", () => {
+		const err = new ApiError("error", "CODE", 400);
+		expect(err.details).toBeUndefined();
+	});
 
-  describe("isUnauthorized()", () => {
-    it("status 401 のとき true を返す", () => {
-      const err = new ApiError("Unauthorized", "UNAUTHORIZED", 401);
-      expect(err.isUnauthorized()).toBe(true);
-    });
+	describe("isUnauthorized()", () => {
+		it("status 401 のとき true を返す", () => {
+			const err = new ApiError("Unauthorized", "UNAUTHORIZED", 401);
+			expect(err.isUnauthorized()).toBe(true);
+		});
 
-    it("status 401 以外のとき false を返す", () => {
-      const err = new ApiError("Not found", "NOT_FOUND", 404);
-      expect(err.isUnauthorized()).toBe(false);
-    });
-  });
+		it("status 401 以外のとき false を返す", () => {
+			const err = new ApiError("Not found", "NOT_FOUND", 404);
+			expect(err.isUnauthorized()).toBe(false);
+		});
+	});
 
-  describe("isValidationError()", () => {
-    it("code が VALIDATION_ERROR のとき true を返す", () => {
-      const err = new ApiError("Validation error", "VALIDATION_ERROR", 400);
-      expect(err.isValidationError()).toBe(true);
-    });
+	describe("isValidationError()", () => {
+		it("code が VALIDATION_ERROR のとき true を返す", () => {
+			const err = new ApiError("Validation error", "VALIDATION_ERROR", 400);
+			expect(err.isValidationError()).toBe(true);
+		});
 
-    it("code が VALIDATION_ERROR 以外のとき false を返す", () => {
-      const err = new ApiError("Not found", "NOT_FOUND", 404);
-      expect(err.isValidationError()).toBe(false);
-    });
-  });
+		it("code が VALIDATION_ERROR 以外のとき false を返す", () => {
+			const err = new ApiError("Not found", "NOT_FOUND", 404);
+			expect(err.isValidationError()).toBe(false);
+		});
+	});
 
-  describe("isNotFound()", () => {
-    it("status 404 のとき true を返す", () => {
-      const err = new ApiError("Not found", "NOT_FOUND", 404);
-      expect(err.isNotFound()).toBe(true);
-    });
+	describe("isNotFound()", () => {
+		it("status 404 のとき true を返す", () => {
+			const err = new ApiError("Not found", "NOT_FOUND", 404);
+			expect(err.isNotFound()).toBe(true);
+		});
 
-    it("status 404 以外のとき false を返す", () => {
-      const err = new ApiError("error", "CODE", 500);
-      expect(err.isNotFound()).toBe(false);
-    });
-  });
+		it("status 404 以外のとき false を返す", () => {
+			const err = new ApiError("error", "CODE", 500);
+			expect(err.isNotFound()).toBe(false);
+		});
+	});
 
-  it("Error のインスタンスである", () => {
-    const err = new ApiError("error", "CODE", 500);
-    expect(err instanceof Error).toBe(true);
-    expect(err instanceof ApiError).toBe(true);
-  });
+	it("Error のインスタンスである", () => {
+		const err = new ApiError("error", "CODE", 500);
+		expect(err instanceof Error).toBe(true);
+		expect(err instanceof ApiError).toBe(true);
+	});
 });
 
 describe("isApiErrorResponse", () => {
-  it("標準エラー形式のオブジェクトを true と判定する", () => {
-    expect(
-      isApiErrorResponse({ success: false, error: "msg", code: "CODE" })
-    ).toBe(true);
-  });
+	it("標準エラー形式のオブジェクトを true と判定する", () => {
+		expect(
+			isApiErrorResponse({ success: false, error: "msg", code: "CODE" }),
+		).toBe(true);
+	});
 
-  it("details があっても true を返す", () => {
-    expect(
-      isApiErrorResponse({
-        success: false,
-        error: "msg",
-        code: "CODE",
-        details: [{ message: "detail" }],
-      })
-    ).toBe(true);
-  });
+	it("details があっても true を返す", () => {
+		expect(
+			isApiErrorResponse({
+				success: false,
+				error: "msg",
+				code: "CODE",
+				details: [{ message: "detail" }],
+			}),
+		).toBe(true);
+	});
 
-  it("success が true の場合は false を返す", () => {
-    expect(
-      isApiErrorResponse({ success: true, error: "msg", code: "CODE" })
-    ).toBe(false);
-  });
+	it("success が true の場合は false を返す", () => {
+		expect(
+			isApiErrorResponse({ success: true, error: "msg", code: "CODE" }),
+		).toBe(false);
+	});
 
-  it("error フィールドがない場合は false を返す", () => {
-    expect(isApiErrorResponse({ success: false, code: "CODE" })).toBe(false);
-  });
+	it("error フィールドがない場合は false を返す", () => {
+		expect(isApiErrorResponse({ success: false, code: "CODE" })).toBe(false);
+	});
 
-  it("code フィールドがない場合は false を返す", () => {
-    expect(isApiErrorResponse({ success: false, error: "msg" })).toBe(false);
-  });
+	it("code フィールドがない場合は false を返す", () => {
+		expect(isApiErrorResponse({ success: false, error: "msg" })).toBe(false);
+	});
 
-  it("null の場合は false を返す", () => {
-    expect(isApiErrorResponse(null)).toBe(false);
-  });
+	it("null の場合は false を返す", () => {
+		expect(isApiErrorResponse(null)).toBe(false);
+	});
 
-  it("文字列の場合は false を返す", () => {
-    expect(isApiErrorResponse("error string")).toBe(false);
-  });
+	it("文字列の場合は false を返す", () => {
+		expect(isApiErrorResponse("error string")).toBe(false);
+	});
+});
+
+describe("getUserFacingErrorMessage", () => {
+	it.each([
+		[new ApiError("Unauthorized", "UNAUTHORIZED", 401), "ログインが必要です。"],
+		[
+			new ApiError("Forbidden", "FORBIDDEN", 403),
+			"この操作を行う権限がありません。",
+		],
+		[
+			new ApiError("Not found", "NOT_FOUND", 404),
+			"対象のデータが見つかりません。",
+		],
+		[new ApiError("Invalid", "VALIDATION_ERROR", 400), "Invalid"],
+		[new ApiError("Already exists", "CONFLICT", 409), "Already exists"],
+		[
+			new ApiError("Server error", "INTERNAL_SERVER_ERROR", 500),
+			"サーバーで問題が発生しました。時間をおいて再度お試しください。",
+		],
+	])("ApiError をユーザー向け文言へ変換する", (error, expected) => {
+		expect(getUserFacingErrorMessage(error)).toBe(expected);
+	});
+
+	it("fetch 失敗をネットワークエラーとして扱う", () => {
+		expect(getUserFacingErrorMessage(new TypeError("Failed to fetch"))).toBe(
+			"ネットワークに接続できません。通信状況を確認してください。",
+		);
+	});
+
+	it("Firebase エラーコードを日本語へ変換する", () => {
+		const error = new Error("Firebase error") as Error & { code: string };
+		error.code = "auth/email-already-in-use";
+
+		expect(getUserFacingErrorMessage(error)).toBe(
+			"このメールアドレスはすでに登録されています。",
+		);
+	});
+
+	it("不明なエラーでは fallback を返す", () => {
+		expect(getUserFacingErrorMessage("unknown", "失敗しました。")).toBe(
+			"失敗しました。",
+		);
+	});
+});
+
+describe("getValidationFieldErrors", () => {
+	it("field 付き details だけを項目エラーへ変換する", () => {
+		const error = new ApiError("Invalid", "VALIDATION_ERROR", 400, [
+			{ field: "title", message: "タイトルは必須です" },
+			{ message: "全体エラー" },
+		]);
+
+		expect(getValidationFieldErrors(error)).toEqual({
+			title: "タイトルは必須です",
+		});
+	});
+
+	it("validation error 以外は空オブジェクトを返す", () => {
+		expect(
+			getValidationFieldErrors(new ApiError("Conflict", "CONFLICT", 409)),
+		).toEqual({});
+	});
+});
+
+describe("isAuthRequiredError", () => {
+	it("401/403 を認証・権限エラーとして判定する", () => {
+		expect(
+			isAuthRequiredError(new ApiError("Unauthorized", "UNAUTHORIZED", 401)),
+		).toBe(true);
+		expect(
+			isAuthRequiredError(new ApiError("Forbidden", "FORBIDDEN", 403)),
+		).toBe(true);
+		expect(
+			isAuthRequiredError(new ApiError("Not found", "NOT_FOUND", 404)),
+		).toBe(false);
+	});
 });

--- a/apps/frontend/src/__tests__/services/httpClient.test.ts
+++ b/apps/frontend/src/__tests__/services/httpClient.test.ts
@@ -1,5 +1,12 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { httpRequest, authenticatedHttpRequest } from "@/services/httpClient";
+import { ApiError } from "@/services/apiError";
+import { authenticatedHttpRequest, httpRequest } from "@/services/httpClient";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockGetIdToken = vi.fn<() => string | null>();
+
+vi.mock("@/services/auth/googleAuth", () => ({
+	getIdToken: () => mockGetIdToken(),
+}));
 
 // config モック
 vi.mock("@/constants/config", () => ({
@@ -88,7 +95,7 @@ describe("httpRequest", () => {
 		);
 	});
 
-	it("HTTP エラー時に Error をスロー（JSON レスポンス）", async () => {
+	it("HTTP エラー時に ApiError をスロー（旧 JSON レスポンス）", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce(
 			new Response(JSON.stringify({ message: "Not Found" }), {
 				status: 404,
@@ -96,12 +103,15 @@ describe("httpRequest", () => {
 			}),
 		);
 
-		await expect(httpRequest({ path: "/quests/999" })).rejects.toThrow(
-			"HTTP 404: Not Found",
-		);
+		await expect(httpRequest({ path: "/quests/999" })).rejects.toMatchObject({
+			name: "ApiError",
+			code: "NOT_FOUND",
+			status: 404,
+			message: "Not Found",
+		});
 	});
 
-	it("HTTP エラー時に Error をスロー（テキストレスポンス）", async () => {
+	it("HTTP エラー時に ApiError をスロー（テキストレスポンス）", async () => {
 		vi.mocked(fetch).mockResolvedValueOnce(
 			new Response("Internal Server Error", {
 				status: 500,
@@ -109,14 +119,74 @@ describe("httpRequest", () => {
 			}),
 		);
 
-		await expect(httpRequest({ path: "/quests" })).rejects.toThrow("HTTP 500");
+		await expect(httpRequest({ path: "/quests" })).rejects.toMatchObject({
+			name: "ApiError",
+			code: "INTERNAL_SERVER_ERROR",
+			status: 500,
+			message: "Internal Server Error",
+		});
+	});
+
+	it("標準エラーレスポンスを ApiError として保持する", async () => {
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(
+				JSON.stringify({
+					success: false,
+					error: "Invalid title",
+					code: "VALIDATION_ERROR",
+					details: [{ field: "title", message: "タイトルは必須です" }],
+				}),
+				{
+					status: 400,
+					headers: { "Content-Type": "application/json" },
+				},
+			),
+		);
+
+		await expect(httpRequest({ path: "/quests" })).rejects.toMatchObject({
+			name: "ApiError",
+			code: "VALIDATION_ERROR",
+			status: 400,
+			details: [{ field: "title", message: "タイトルは必須です" }],
+		});
 	});
 });
 
 describe("authenticatedHttpRequest", () => {
-	it("currentUser が null の場合に Error をスロー", async () => {
-		await expect(authenticatedHttpRequest({ path: "/quests" })).rejects.toThrow(
-			"User not authenticated",
+	beforeEach(() => {
+		mockGetIdToken.mockReturnValue(null);
+	});
+
+	it("ID token がない場合に ApiError をスロー", async () => {
+		await expect(authenticatedHttpRequest({ path: "/quests" })).rejects.toEqual(
+			expect.any(ApiError),
+		);
+		await expect(
+			authenticatedHttpRequest({ path: "/quests" }),
+		).rejects.toMatchObject({
+			code: "UNAUTHORIZED",
+			status: 401,
+		});
+	});
+
+	it("ID token を Authorization ヘッダーに付与する", async () => {
+		mockGetIdToken.mockReturnValue("google-token");
+		vi.mocked(fetch).mockResolvedValueOnce(
+			new Response(JSON.stringify({ ok: true }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			}),
+		);
+
+		await authenticatedHttpRequest({ path: "/users/me" });
+
+		expect(fetch).toHaveBeenCalledWith(
+			expect.any(String),
+			expect.objectContaining({
+				headers: expect.objectContaining({
+					Authorization: "Bearer google-token",
+				}),
+			}),
 		);
 	});
 });

--- a/apps/frontend/src/app/login/_components/GoogleLoginForm.tsx
+++ b/apps/frontend/src/app/login/_components/GoogleLoginForm.tsx
@@ -1,6 +1,8 @@
 "use client";
 
+import { useToast } from "@/components/providers/ToastProvider";
 import { useAuth } from "@/hooks/useAuth";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import { authenticatedApiClient } from "@/services/httpClient";
 import type { CredentialResponse } from "@react-oauth/google";
 import { GoogleLogin, GoogleOAuthProvider } from "@react-oauth/google";
@@ -11,6 +13,7 @@ const clientId = process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "";
 export default function GoogleLoginForm() {
 	const router = useRouter();
 	const { login, logout } = useAuth();
+	const { showToast } = useToast();
 
 	const handleSuccess = async (response: CredentialResponse) => {
 		if (!response.credential) return;
@@ -23,12 +26,18 @@ export default function GoogleLoginForm() {
 		} catch (error) {
 			console.error("ユーザー同期エラー:", error);
 			logout();
-			alert("ログインに失敗しました。再度お試しください。");
+			showToast(
+				getUserFacingErrorMessage(
+					error,
+					"ログインに失敗しました。再度お試しください。",
+				),
+				"error",
+			);
 		}
 	};
 
 	const handleError = () => {
-		alert("Google ログインに失敗しました。再度お試しください。");
+		showToast("Google ログインに失敗しました。再度お試しください。", "error");
 	};
 
 	return (

--- a/apps/frontend/src/components/ClientProviders.tsx
+++ b/apps/frontend/src/components/ClientProviders.tsx
@@ -1,9 +1,14 @@
 "use client";
 
+import { ToastProvider } from "@/components/providers/ToastProvider";
 import { AuthProvider } from "@/contexts/AuthContext";
 
 export const ClientProviders: React.FC<{ children: React.ReactNode }> = ({
 	children,
 }) => {
-	return <AuthProvider>{children}</AuthProvider>;
+	return (
+		<ToastProvider>
+			<AuthProvider>{children}</AuthProvider>
+		</ToastProvider>
+	);
 };

--- a/apps/frontend/src/components/organisms/AdminDashboard.tsx
+++ b/apps/frontend/src/components/organisms/AdminDashboard.tsx
@@ -1,10 +1,12 @@
 "use client";
 
+import { useToast } from "@/components/providers/ToastProvider";
 import {
 	getQuestStatusBadgeClass,
 	getQuestStatusLabel,
 } from "@/constants/questPresentation";
 import { useAuth } from "@/hooks/useAuth";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import type { Quest } from "@quest-board/types";
 import {
 	AlertCircle,
@@ -43,6 +45,7 @@ type QuestCategory = "education" | "security" | "event" | "innovation";
 
 const AdminDashboard = () => {
 	const { loading: authLoading, isAuthenticated } = useAuth();
+	const { showToast } = useToast();
 	const [activeTab, setActiveTab] = useState<"dashboard" | "quests" | "users">(
 		"dashboard",
 	);
@@ -57,21 +60,9 @@ const AdminDashboard = () => {
 	const [questToDelete, setQuestToDelete] = useState<Quest | null>(null);
 	const [questToEdit, setQuestToEdit] = useState<Quest | null>(null);
 	const [userToDelete, setUserToDelete] = useState<UserResponse | null>(null);
-	const [toastMessage, setToastMessage] = useState<string | null>(null);
-
-	// トースト通知を表示する関数
-	const showToast = (message: string) => {
-		setToastMessage(message);
-		setTimeout(() => {
-			setToastMessage(null);
-		}, 3000); // 3秒後に自動で非表示
-	};
 
 	const getErrorMessage = (error: unknown) => {
-		if (error instanceof Error && error.message.startsWith("HTTP 403")) {
-			return "管理者権限が必要です";
-		}
-		return "データの取得に失敗しました";
+		return getUserFacingErrorMessage(error, "データの取得に失敗しました。");
 	};
 
 	// クエストデータとユーザーデータを取得
@@ -104,13 +95,14 @@ const AdminDashboard = () => {
 			} catch (err) {
 				console.error("Failed to fetch data:", err);
 				setError(getErrorMessage(err));
+				showToast(getErrorMessage(err), "error");
 			} finally {
 				setLoading(false);
 			}
 		};
 
 		fetchData();
-	}, [authLoading, isAuthenticated]);
+	}, [authLoading, isAuthenticated, showToast]);
 
 	const dashboardStats = {
 		totalQuests: quests.length,
@@ -166,38 +158,46 @@ const AdminDashboard = () => {
 		try {
 			if (action === "approve") {
 				await questService.updateQuestStatus(questId.toString(), "active");
+				showToast("クエストを承認しました。", "success");
 			} else if (action === "reject") {
 				await questService.updateQuestStatus(questId.toString(), "draft");
 				// 却下時のトースト通知表示（API呼び出し成功後）
-				showToast("クエストを却下しました。ステータスが下書きに戻されました。");
+				showToast(
+					"クエストを却下しました。ステータスが下書きに戻されました。",
+					"success",
+				);
 			} else if (action === "hide") {
 				await questService.updateQuestStatus(questId.toString(), "inactive");
+				showToast("クエストを非表示にしました。", "success");
 			} else if (action === "publish") {
 				await questService.updateQuestStatus(questId.toString(), "active");
+				showToast("クエストを公開しました。", "success");
 			} else if (action === "submit_for_approval") {
 				await questService.updateQuestStatus(questId.toString(), "pending");
 				// 承認待ち申請時のトースト通知表示
 				showToast(
 					"クエストを承認待ちにしました。管理者の承認をお待ちください。",
+					"success",
 				);
 			} else if (action === "start_progress") {
 				await questService.updateQuestStatus(questId.toString(), "in_progress");
 				// 進行中開始時のトースト通知表示
-				showToast("クエストを進行中にしました。");
+				showToast("クエストを進行中にしました。", "success");
 			} else if (action === "complete") {
 				await questService.updateQuestStatus(questId.toString(), "completed");
 				// 完了時のトースト通知表示
-				showToast("クエストを完了にしました。");
+				showToast("クエストを完了にしました。", "success");
 			} else if (action === "reactivate") {
 				await questService.reactivateQuest(questId.toString());
+				showToast("クエストを再有効化しました。", "success");
 			} else if (action === "submit_for_approval") {
 				await questService.submitQuestForApproval(questId.toString());
 				// 承認待ち申請時のトースト通知表示
-				showToast("クエストを承認待ちに申請しました。");
+				showToast("クエストを承認待ちに申請しました。", "success");
 			} else if (action === "restore") {
 				await questService.restoreQuest(questId.toString());
 				// 復元時のトースト通知表示
-				showToast("クエストを復元しました。");
+				showToast("クエストを復元しました。", "success");
 			} else if (action === "edit") {
 				const quest = quests.find((q) => q.id === questId);
 				if (quest) {
@@ -218,7 +218,10 @@ const AdminDashboard = () => {
 			setSelectedQuest(null);
 		} catch (err) {
 			console.error(`Failed to ${action} quest:`, err);
-			setError(`クエストの${action}に失敗しました`);
+			showToast(
+				getUserFacingErrorMessage(err, `クエストの${action}に失敗しました。`),
+				"error",
+			);
 		}
 	};
 
@@ -236,7 +239,7 @@ const AdminDashboard = () => {
 				}
 			} else if (action === "updateRole" && newRole) {
 				await userService.updateUserRole(userId, newRole);
-				showToast(`ユーザーのロールを${newRole}に変更しました`);
+				showToast(`ユーザーのロールを${newRole}に変更しました。`, "success");
 
 				// ユーザーリストを再取得
 				const userData = await userService.getAllUsers();
@@ -244,7 +247,10 @@ const AdminDashboard = () => {
 			}
 		} catch (error) {
 			console.error("ユーザーアクションエラー:", error);
-			showToast("操作に失敗しました");
+			showToast(
+				getUserFacingErrorMessage(error, "操作に失敗しました。"),
+				"error",
+			);
 		}
 	};
 
@@ -259,9 +265,13 @@ const AdminDashboard = () => {
 			setQuests(questData);
 			setQuestToDelete(null);
 			setSelectedQuest(null);
+			showToast("クエストを削除しました。", "success");
 		} catch (err) {
 			console.error("Failed to delete quest:", err);
-			setError("クエストの削除に失敗しました");
+			showToast(
+				getUserFacingErrorMessage(err, "クエストの削除に失敗しました。"),
+				"error",
+			);
 		}
 	};
 
@@ -275,10 +285,13 @@ const AdminDashboard = () => {
 			const userData = await userService.getAllUsers();
 			setUsers(userData);
 			setUserToDelete(null);
-			showToast("ユーザーを削除しました");
+			showToast("ユーザーを削除しました。", "success");
 		} catch (err) {
 			console.error("Failed to delete user:", err);
-			setError("ユーザーの削除に失敗しました");
+			showToast(
+				getUserFacingErrorMessage(err, "ユーザーの削除に失敗しました。"),
+				"error",
+			);
 		}
 	};
 
@@ -381,10 +394,15 @@ const AdminDashboard = () => {
 				// クエストリストを再取得（管理者用：削除済みも含む）
 				const questData = await questService.getAllQuestsIncludingDeleted();
 				setQuests(questData);
+				showToast("クエストを作成しました。", "success");
 				onClose();
 			} catch (err) {
 				console.error("Failed to create quest:", err);
-				setError("クエストの作成に失敗しました");
+				showToast(
+					getUserFacingErrorMessage(err, "クエストの作成に失敗しました。"),
+					"error",
+				);
+				throw err;
 			}
 		};
 
@@ -450,11 +468,15 @@ const AdminDashboard = () => {
 				// クエストリストを再取得（管理者用：削除済みも含む）
 				const questData = await questService.getAllQuestsIncludingDeleted();
 				setQuests(questData);
-				showToast("クエストを更新しました。");
+				showToast("クエストを更新しました。", "success");
 				onClose();
 			} catch (err) {
 				console.error("Failed to update quest:", err);
-				setError("クエストの更新に失敗しました");
+				showToast(
+					getUserFacingErrorMessage(err, "クエストの更新に失敗しました。"),
+					"error",
+				);
+				throw err;
 			}
 		};
 
@@ -1124,16 +1146,6 @@ const AdminDashboard = () => {
 					onConfirm={handleUserDeleteConfirm}
 					onCancel={() => setUserToDelete(null)}
 				/>
-			)}
-
-			{/* トースト通知 */}
-			{toastMessage && (
-				<div className="fixed top-4 right-4 z-50 bg-green-600 text-white px-6 py-3 rounded-lg shadow-lg animate-pulse">
-					<div className="flex items-center gap-2">
-						<Check className="w-5 h-5" />
-						<span>{toastMessage}</span>
-					</div>
-				</div>
 			)}
 		</div>
 	);

--- a/apps/frontend/src/components/organisms/Header.tsx
+++ b/apps/frontend/src/components/organisms/Header.tsx
@@ -1,12 +1,14 @@
 "use client";
 
-import type React from "react";
-import { useState, useEffect, useRef } from "react";
-import Link from "next/link";
-import { useRouter, usePathname } from "next/navigation";
-import { Sword, Bell, User, Settings, LogOut, Menu, X } from "lucide-react";
+import { useToast } from "@/components/providers/ToastProvider";
 import { useAuth } from "@/hooks/useAuth";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import { userService } from "@/services/user";
+import { Bell, LogOut, Menu, Settings, Sword, User, X } from "lucide-react";
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface AppUser {
 	name?: string;
@@ -19,6 +21,7 @@ export const Header: React.FC = () => {
 	const router = useRouter();
 	const pathname = usePathname();
 	const { user: googleUser, logout } = useAuth();
+	const { showToast } = useToast();
 	const [appUser, setAppUser] = useState<AppUser | null>(null);
 	const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 	const mobileMenuRef = useRef<HTMLElement | null>(null);
@@ -49,10 +52,13 @@ export const Header: React.FC = () => {
 	const handleLogout = async () => {
 		try {
 			logout();
+			showToast("ログアウトしました。", "success");
 			router.push("/");
 		} catch (error: unknown) {
-			const message = error instanceof Error ? error.message : String(error);
-			alert(`ログアウトエラー: ${message}`);
+			showToast(
+				getUserFacingErrorMessage(error, "ログアウトに失敗しました。"),
+				"error",
+			);
 		}
 	};
 

--- a/apps/frontend/src/components/organisms/QuestEditorForm.tsx
+++ b/apps/frontend/src/components/organisms/QuestEditorForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { getValidationFieldErrors } from "@/services/apiError";
 import {
 	QUEST_STATUS_LABELS,
 	QUEST_STATUS_VALUES,
@@ -40,6 +41,15 @@ type QuestEditorFormProps = {
 
 const fieldBaseClassName =
 	"w-full rounded-lg border-2 border-amber-300 bg-amber-50 px-3 py-2 text-slate-800 focus:border-yellow-400 focus:outline-none";
+
+const apiFieldMap: Record<string, keyof QuestFormErrors> = {
+	title: "title",
+	description: "description",
+	start_date: "start_date",
+	end_date: "end_date",
+	maxParticipants: "maxParticipants",
+	max_participants: "maxParticipants",
+};
 
 export const QuestEditorForm: React.FC<QuestEditorFormProps> = ({
 	title,
@@ -182,6 +192,21 @@ export const QuestEditorForm: React.FC<QuestEditorFormProps> = ({
 			window.localStorage.removeItem(draftStorageKey);
 			setInitialSerialized(JSON.stringify(formData));
 			setIsDraftRestored(false);
+		} catch (error) {
+			const fieldErrors = getValidationFieldErrors(error);
+			const nextErrors = Object.entries(fieldErrors).reduce<QuestFormErrors>(
+				(acc, [field, message]) => {
+					const mappedField = apiFieldMap[field];
+					if (mappedField) {
+						acc[mappedField] = message;
+					}
+					return acc;
+				},
+				{},
+			);
+			if (Object.keys(nextErrors).length > 0) {
+				setErrors(nextErrors);
+			}
 		} finally {
 			setIsSubmitting(false);
 		}

--- a/apps/frontend/src/components/organisms/QuestJoinDialog.tsx
+++ b/apps/frontend/src/components/organisms/QuestJoinDialog.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useToast } from "@/components/providers/ToastProvider";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import { authenticatedApiClient } from "@/services/httpClient";
 import {
 	Box,
@@ -24,6 +26,8 @@ const QuestJoinDialog: React.FC<QuestJoinDialogProps> = ({
 	isOpen,
 	onClose,
 }) => {
+	const { showToast } = useToast();
+
 	if (!quest) return null;
 
 	const currentParticipants = quest._count?.quest_participants || 0;
@@ -45,19 +49,18 @@ const QuestJoinDialog: React.FC<QuestJoinDialogProps> = ({
 			>(`/quests/${quest.id}/participants`, {});
 
 			if (data.success) {
-				alert("クエストに参加しました！");
+				showToast("クエストに参加しました。", "success");
 				onClose(); // ダイアログを閉じる
 				// 参加者数更新など必要なら state を更新
 			} else {
-				alert(data.message || "参加できませんでした");
+				showToast(data.message || "参加できませんでした。", "error");
 			}
 		} catch (err) {
 			console.error(err);
-			if (err instanceof Error && err.message === "User not authenticated") {
-				alert("ログイン状態を確認してください");
-				return;
-			}
-			alert("参加に失敗しました");
+			showToast(
+				getUserFacingErrorMessage(err, "参加に失敗しました。"),
+				"error",
+			);
 		}
 	};
 

--- a/apps/frontend/src/components/organisms/QuestList.tsx
+++ b/apps/frontend/src/components/organisms/QuestList.tsx
@@ -9,6 +9,7 @@ import {
 	filterQuests,
 	getSuggestedQuests,
 } from "@/components/organisms/questListFilters";
+import { useToast } from "@/components/providers/ToastProvider";
 import {
 	HIDDEN_QUEST_STATUSES,
 	getQuestDifficultyBadgeClass,
@@ -16,6 +17,7 @@ import {
 } from "@/constants/questPresentation";
 import { useAuth } from "@/hooks/useAuth";
 import { useSearchHistory } from "@/hooks/useSearchHistory";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import { questService } from "@/services/quest";
 import { reviewService } from "@/services/review";
 import { userService } from "@/services/user";
@@ -90,12 +92,14 @@ const QuestList: React.FC = () => {
 	>(new Map());
 	const [currentUserId, setCurrentUserId] = useState<number | null>(null);
 	const searchContainerRef = useRef<HTMLDivElement | null>(null);
+	const reviewCheckToastShownRef = useRef(false);
 	const {
 		history: searchHistory,
 		addHistory,
 		clearHistory,
 	} = useSearchHistory();
 	const { user, isAuthenticated } = useAuth();
+	const { showToast } = useToast();
 	const router = useRouter();
 
 	useEffect(() => {
@@ -106,12 +110,16 @@ const QuestList: React.FC = () => {
 			} catch (err) {
 				console.error(err);
 				setQuests([]);
+				showToast(
+					getUserFacingErrorMessage(err, "クエスト一覧の取得に失敗しました。"),
+					"error",
+				);
 			} finally {
 				setLoading(false);
 			}
 		};
 		fetchQuests();
-	}, []);
+	}, [showToast]);
 
 	useEffect(() => {
 		const timerId = window.setTimeout(() => {
@@ -135,11 +143,12 @@ const QuestList: React.FC = () => {
 			} catch (error) {
 				console.error("QuestList: ユーザーID取得エラー:", error);
 				setCurrentUserId(null);
+				showToast("ユーザー情報の取得に失敗しました。", "error");
 			}
 		};
 
 		fetchUserId();
-	}, [user, isAuthenticated]);
+	}, [user, isAuthenticated, showToast]);
 
 	// クエストデータが取得されたら、各クエストのボタンアクションを決定
 	useEffect(() => {
@@ -220,6 +229,10 @@ const QuestList: React.FC = () => {
 			return response.exists;
 		} catch (error) {
 			console.error("レビュー投稿状況確認エラー:", error);
+			if (!reviewCheckToastShownRef.current) {
+				showToast("レビュー投稿状況を確認できませんでした。", "info");
+				reviewCheckToastShownRef.current = true;
+			}
 			return false;
 		}
 	};

--- a/apps/frontend/src/components/pages/MyPage.tsx
+++ b/apps/frontend/src/components/pages/MyPage.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import type React from "react";
-import { useEffect, useState } from "react";
-import UserProfile from "../organisms/UserProfile";
-import QuestHistory from "../organisms/QuestHistory";
-import NotificationList from "../organisms/NotificationList";
+import { useToast } from "@/components/providers/ToastProvider";
 import { useAuth } from "@/hooks/useAuth";
+import { useMyPageData } from "@/hooks/useMyPageData";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import { userService } from "@/services/user";
 import type { UserResponse } from "@/services/user";
-import { useMyPageData } from "@/hooks/useMyPageData";
+import type React from "react";
+import { useEffect, useState } from "react";
+import NotificationList from "../organisms/NotificationList";
+import QuestHistory from "../organisms/QuestHistory";
+import UserProfile from "../organisms/UserProfile";
 
 const MyPage: React.FC = () => {
 	const { user: authUser } = useAuth();
 	const [user, setUser] = useState<UserResponse | null>(null);
 	const { notifications, questGroups } = useMyPageData();
+	const { showToast } = useToast();
 
 	// 認証ユーザーが確定・変化したらDBユーザーを取得（ヘッダーと同様）
 	useEffect(() => {
@@ -28,12 +31,16 @@ const MyPage: React.FC = () => {
 				}
 			} catch (e) {
 				console.error("/users/me の取得に失敗しました", e);
+				showToast(
+					getUserFacingErrorMessage(e, "ユーザー情報の取得に失敗しました。"),
+					"error",
+				);
 			}
 		})();
 		return () => {
 			cancelled = true;
 		};
-	}, [authUser]);
+	}, [authUser, showToast]);
 
 	return (
 		<main className="min-h-screen bg-gradient-to-b from-gray-800 to-gray-900 px-6 py-10">

--- a/apps/frontend/src/components/pages/QuestDetailPage.tsx
+++ b/apps/frontend/src/components/pages/QuestDetailPage.tsx
@@ -1,359 +1,395 @@
 "use client";
 
-import React, { useState, useEffect } from "react";
+import { useToast } from "@/components/providers/ToastProvider";
+import { ApiError, getUserFacingErrorMessage } from "@/services/apiError";
+import {
+	type NewReview,
+	type Quest,
+	QuestStatus,
+	type Review,
+} from "@quest-board/types";
+import type React from "react";
+import { useEffect, useState } from "react";
+import { useAuth } from "../../hooks/useAuth";
+import { questService } from "../../services/quest";
+import { type ReviewResponse, reviewService } from "../../services/review";
+import { userService } from "../../services/user";
 import StatusRibbon from "../atoms/StatusRibbon";
 import Tag from "../atoms/Tag";
 import ReviewSection from "../organisms/ReviewSection";
-import { Quest, QuestStatus, Review, NewReview } from "@quest-board/types";
-import { questService } from "../../services/quest";
-import { reviewService, ReviewResponse } from "../../services/review";
-import { userService } from "../../services/user";
-import { useAuth } from "../../hooks/useAuth";
 
 interface QuestDetailPageProps {
-  questId?: string;
-  action?: string;
+	questId?: string;
+	action?: string;
 }
 
 const QuestDetailSkeleton = () => (
-  <div className="max-w-4xl mx-auto px-4 py-8 space-y-8 animate-pulse">
-    <div className="rounded-xl border-2 border-amber-200 bg-gradient-to-br from-amber-50 to-amber-100 p-6 shadow-lg">
-      <div className="mb-5 h-6 w-24 rounded-full bg-amber-200" />
-      <div className="space-y-3">
-        <div className="h-8 w-2/3 rounded bg-amber-300/70" />
-        <div className="h-4 w-full rounded bg-amber-200/80" />
-        <div className="h-4 w-5/6 rounded bg-amber-200/80" />
-      </div>
-      <div className="mt-6 flex flex-wrap gap-2">
-        <div className="h-7 w-24 rounded-full bg-amber-200" />
-        <div className="h-7 w-16 rounded-full bg-amber-200" />
-        <div className="h-7 w-20 rounded-full bg-amber-200" />
-      </div>
-    </div>
+	<div className="max-w-4xl mx-auto px-4 py-8 space-y-8 animate-pulse">
+		<div className="rounded-xl border-2 border-amber-200 bg-gradient-to-br from-amber-50 to-amber-100 p-6 shadow-lg">
+			<div className="mb-5 h-6 w-24 rounded-full bg-amber-200" />
+			<div className="space-y-3">
+				<div className="h-8 w-2/3 rounded bg-amber-300/70" />
+				<div className="h-4 w-full rounded bg-amber-200/80" />
+				<div className="h-4 w-5/6 rounded bg-amber-200/80" />
+			</div>
+			<div className="mt-6 flex flex-wrap gap-2">
+				<div className="h-7 w-24 rounded-full bg-amber-200" />
+				<div className="h-7 w-16 rounded-full bg-amber-200" />
+				<div className="h-7 w-20 rounded-full bg-amber-200" />
+			</div>
+		</div>
 
-    <div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div className="mb-6 h-7 w-48 rounded bg-slate-200" />
-      <div className="space-y-4">
-        {Array.from({ length: 3 }).map((_, index) => (
-          <div key={index} className="space-y-3 rounded-2xl border border-slate-100 p-4">
-            <div className="flex items-center justify-between">
-              <div className="h-5 w-32 rounded bg-slate-200" />
-              <div className="h-4 w-20 rounded bg-slate-100" />
-            </div>
-            <div className="h-4 w-full rounded bg-slate-100" />
-            <div className="h-4 w-4/5 rounded bg-slate-100" />
-          </div>
-        ))}
-      </div>
-    </div>
-  </div>
+		<div className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+			<div className="mb-6 h-7 w-48 rounded bg-slate-200" />
+			<div className="space-y-4">
+				{Array.from({ length: 3 }).map((_, index) => (
+					<div
+						key={`review-skeleton-${index + 1}`}
+						className="space-y-3 rounded-2xl border border-slate-100 p-4"
+					>
+						<div className="flex items-center justify-between">
+							<div className="h-5 w-32 rounded bg-slate-200" />
+							<div className="h-4 w-20 rounded bg-slate-100" />
+						</div>
+						<div className="h-4 w-full rounded bg-slate-100" />
+						<div className="h-4 w-4/5 rounded bg-slate-100" />
+					</div>
+				))}
+			</div>
+		</div>
+	</div>
 );
 
 const QuestDetailPage: React.FC<QuestDetailPageProps> = ({
-  questId,
-  action,
+	questId,
+	action,
 }) => {
-  const [quest, setQuest] = useState<Quest | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [reviews, setReviews] = useState<Review[]>([]);
-  const [newReview, setNewReview] = useState<NewReview>({
-    score: 0,
-    comment: "",
-  });
-  const [showReviewForm, setShowReviewForm] = useState(false);
-  const [currentUserId, setCurrentUserId] = useState<number | null>(null);
-  const { user, isAuthenticated } = useAuth();
+	const [quest, setQuest] = useState<Quest | null>(null);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | null>(null);
+	const [reviews, setReviews] = useState<Review[]>([]);
+	const [newReview, setNewReview] = useState<NewReview>({
+		score: 0,
+		comment: "",
+	});
+	const [showReviewForm, setShowReviewForm] = useState(false);
+	const [currentUserId, setCurrentUserId] = useState<number | null>(null);
+	const { user, isAuthenticated } = useAuth();
+	const { showToast } = useToast();
 
-  // クエストデータとレビューデータを取得
-  useEffect(() => {
-    const fetchData = async () => {
-      if (!questId) {
-        setError("クエストIDが指定されていません");
-        setLoading(false);
-        return;
-      }
+	// クエストデータとレビューデータを取得
+	useEffect(() => {
+		const fetchData = async () => {
+			if (!questId) {
+				setError("クエストIDが指定されていません");
+				setLoading(false);
+				return;
+			}
 
-      try {
-        setLoading(true);
-        setError(null);
+			try {
+				setLoading(true);
+				setError(null);
 
-        // クエストデータとレビューデータを並行取得
-        const [questData, reviewsData] = await Promise.all([
-          questService.getQuestById(questId),
-          reviewService.getReviewsByQuestId(questId).catch(() => []), // レビュー取得失敗時は空配列
-        ]);
+				// クエストデータとレビューデータを並行取得
+				const [questData, reviewsData] = await Promise.all([
+					questService.getQuestById(questId),
+					reviewService.getReviewsByQuestId(questId).catch((error) => {
+						console.error("レビュー取得エラー:", error);
+						showToast("レビューの取得に失敗しました。", "error");
+						return [];
+					}),
+				]);
 
-        setQuest(questData);
+				setQuest(questData);
 
-        // APIから取得したレビューデータを変換
-        const convertedReviews: Review[] = reviewsData.map(
-          (review: ReviewResponse) => ({
-            id: review.id,
-            user: review.reviewer.name,
-            score: review.rating,
-            comment: review.comment || "",
-            date: new Date(review.created_at).toLocaleDateString("ja-JP"),
-            reviewer_id: review.reviewer_id,
-          })
-        );
+				// APIから取得したレビューデータを変換
+				const convertedReviews: Review[] = reviewsData.map(
+					(review: ReviewResponse) => ({
+						id: review.id,
+						user: review.reviewer.name,
+						score: review.rating,
+						comment: review.comment || "",
+						date: new Date(review.created_at).toLocaleDateString("ja-JP"),
+						reviewer_id: review.reviewer_id,
+					}),
+				);
 
-        setReviews(convertedReviews);
-      } catch (err) {
-        console.error("データ取得エラー:", err);
-        setError("データの取得に失敗しました");
-      } finally {
-        setLoading(false);
-      }
-    };
+				setReviews(convertedReviews);
+			} catch (err) {
+				console.error("データ取得エラー:", err);
+				setError("データの取得に失敗しました");
+				showToast(
+					getUserFacingErrorMessage(err, "データの取得に失敗しました。"),
+					"error",
+				);
+			} finally {
+				setLoading(false);
+			}
+		};
 
-    fetchData();
-  }, [questId]);
+		fetchData();
+	}, [questId, showToast]);
 
-  // ユーザーIDを動的に取得
-  useEffect(() => {
-    const fetchUserId = async () => {
-      if (!user || !isAuthenticated) {
-        setCurrentUserId(null);
-        return;
-      }
+	// ユーザーIDを動的に取得
+	useEffect(() => {
+		const fetchUserId = async () => {
+			if (!user || !isAuthenticated) {
+				setCurrentUserId(null);
+				return;
+			}
 
-      try {
-        const userData = await userService.getCurrentUser();
-        setCurrentUserId(userData.id);
-      } catch (error) {
-        console.error("ユーザーID取得エラー:", error);
-        setCurrentUserId(null);
-      }
-    };
+			try {
+				const userData = await userService.getCurrentUser();
+				setCurrentUserId(userData.id);
+			} catch (error) {
+				console.error("ユーザーID取得エラー:", error);
+				setCurrentUserId(null);
+				showToast("ユーザー情報の取得に失敗しました。", "error");
+			}
+		};
 
-    fetchUserId();
-  }, [user, isAuthenticated]);
+		fetchUserId();
+	}, [user, isAuthenticated, showToast]);
 
-  // アクションパラメータに基づいてレビュー投稿フォームを表示
-  useEffect(() => {
-    const checkAndShowReviewForm = async () => {
-      if (
-        action === "review" &&
-        user &&
-        isAuthenticated &&
-        quest &&
-        currentUserId
-      ) {
-        try {
-          // 実際のAPIを呼び出してレビュー投稿状況を確認
-          const response = await reviewService.checkUserReviewExists(
-            currentUserId.toString(),
-            quest.id.toString()
-          );
-          if (!response.exists) {
-            setShowReviewForm(true);
-          }
-        } catch (error) {
-          console.error("レビュー投稿状況確認エラー:", error);
-          setShowReviewForm(true); // エラー時は表示
-        }
-      }
-    };
+	// アクションパラメータに基づいてレビュー投稿フォームを表示
+	useEffect(() => {
+		const checkAndShowReviewForm = async () => {
+			if (
+				action === "review" &&
+				user &&
+				isAuthenticated &&
+				quest &&
+				currentUserId
+			) {
+				try {
+					// 実際のAPIを呼び出してレビュー投稿状況を確認
+					const response = await reviewService.checkUserReviewExists(
+						currentUserId.toString(),
+						quest.id.toString(),
+					);
+					if (!response.exists) {
+						setShowReviewForm(true);
+					}
+				} catch (error) {
+					console.error("レビュー投稿状況確認エラー:", error);
+					showToast("レビュー投稿状況を確認できませんでした。", "info");
+					setShowReviewForm(false);
+				}
+			}
+		};
 
-    checkAndShowReviewForm();
-  }, [action, user, isAuthenticated, quest, currentUserId]);
+		checkAndShowReviewForm();
+	}, [action, user, isAuthenticated, quest, currentUserId, showToast]);
 
-  const getDifficultyColor = (difficulty: string): string => {
-    switch (difficulty) {
-      case "初級":
-        return "bg-green-500";
-      case "中級":
-        return "bg-yellow-500";
-      case "上級":
-        return "bg-red-500";
-      default:
-        return "bg-gray-500";
-    }
-  };
+	const getDifficultyColor = (difficulty: string): string => {
+		switch (difficulty) {
+			case "初級":
+				return "bg-green-500";
+			case "中級":
+				return "bg-yellow-500";
+			case "上級":
+				return "bg-red-500";
+			default:
+				return "bg-gray-500";
+		}
+	};
 
-  const handleSubmitReview = async () => {
-    if (!newReview.comment || newReview.score === 0 || !questId) {
-      return;
-    }
+	const handleSubmitReview = async () => {
+		if (!newReview.comment || newReview.score === 0 || !questId) {
+			return;
+		}
 
-    try {
-      // 動的に取得したユーザーIDを使用
-      if (!currentUserId) {
-        alert("ユーザー情報の取得に失敗しました。もう一度お試しください。");
-        return;
-      }
+		try {
+			// 動的に取得したユーザーIDを使用
+			if (!currentUserId) {
+				showToast(
+					"ユーザー情報の取得に失敗しました。もう一度お試しください。",
+					"error",
+				);
+				return;
+			}
 
-      // APIにレビューを投稿
-      const response = await reviewService.createReview(questId, {
-        rating: newReview.score,
-        comment: newReview.comment,
-      });
+			// APIにレビューを投稿
+			const response = await reviewService.createReview(questId, {
+				rating: newReview.score,
+				comment: newReview.comment,
+			});
 
-      // 成功時はローカル状態を更新
-      const newReviewData: Review = {
-        id: response.id,
-        user: response.reviewer.name,
-        score: response.rating,
-        comment: response.comment || "",
-        date: new Date(response.created_at).toLocaleDateString("ja-JP"),
-        reviewer_id: response.reviewer_id,
-      };
+			// 成功時はローカル状態を更新
+			const newReviewData: Review = {
+				id: response.id,
+				user: response.reviewer.name,
+				score: response.rating,
+				comment: response.comment || "",
+				date: new Date(response.created_at).toLocaleDateString("ja-JP"),
+				reviewer_id: response.reviewer_id,
+			};
 
-      setReviews([newReviewData, ...reviews]);
-      setNewReview({ score: 0, comment: "" });
-      setShowReviewForm(false);
-    } catch (err) {
-      console.error("レビュー投稿エラー:", err);
+			setReviews([newReviewData, ...reviews]);
+			setNewReview({ score: 0, comment: "" });
+			setShowReviewForm(false);
+			showToast("レビューを投稿しました。", "success");
+		} catch (err) {
+			console.error("レビュー投稿エラー:", err);
+			const message = getUserFacingErrorMessage(
+				err,
+				"レビューの投稿に失敗しました。もう一度お試しください。",
+			);
+			showToast(message, "error");
+			if (err instanceof ApiError && err.status === 409) {
+				setShowReviewForm(false);
+			}
+		}
+	};
 
-      // エラー時はアラートを表示
-      if (
-        err instanceof Error &&
-        err.message.includes("既にレビューを投稿済み")
-      ) {
-        alert("このクエストには既にレビューを投稿済みです。");
-        setShowReviewForm(false);
-      } else {
-        alert("レビューの投稿に失敗しました。もう一度お試しください。");
-      }
-    }
-  };
+	// レビュー編集ハンドラー
+	const handleEditReview = async (reviewId: number, data: NewReview) => {
+		try {
+			const response = await reviewService.updateReview(reviewId.toString(), {
+				rating: data.score,
+				comment: data.comment,
+			});
 
-  // レビュー編集ハンドラー
-  const handleEditReview = async (reviewId: number, data: NewReview) => {
-    try {
-      const response = await reviewService.updateReview(reviewId.toString(), {
-        rating: data.score,
-        comment: data.comment,
-      });
+			// 成功時はローカル状態を更新
+			const updatedReviewData: Review = {
+				id: response.id,
+				user: response.reviewer.name,
+				score: response.rating,
+				comment: response.comment || "",
+				date: new Date(response.created_at).toLocaleDateString("ja-JP"),
+				reviewer_id: response.reviewer_id,
+			};
 
-      // 成功時はローカル状態を更新
-      const updatedReviewData: Review = {
-        id: response.id,
-        user: response.reviewer.name,
-        score: response.rating,
-        comment: response.comment || "",
-        date: new Date(response.created_at).toLocaleDateString("ja-JP"),
-        reviewer_id: response.reviewer_id,
-      };
+			setReviews(
+				reviews.map((review) =>
+					review.id === reviewId ? updatedReviewData : review,
+				),
+			);
+			showToast("レビューを更新しました。", "success");
+		} catch (err) {
+			console.error("レビュー編集エラー:", err);
+			showToast(
+				getUserFacingErrorMessage(
+					err,
+					"レビューの編集に失敗しました。もう一度お試しください。",
+				),
+				"error",
+			);
+		}
+	};
 
-      setReviews(
-        reviews.map((review) =>
-          review.id === reviewId ? updatedReviewData : review
-        )
-      );
-    } catch (err) {
-      console.error("レビュー編集エラー:", err);
-      alert("レビューの編集に失敗しました。もう一度お試しください。");
-    }
-  };
+	// レビュー削除ハンドラー
+	const handleDeleteReview = async (reviewId: number) => {
+		try {
+			await reviewService.deleteReview(reviewId.toString());
 
-  // レビュー削除ハンドラー
-  const handleDeleteReview = async (reviewId: number) => {
-    try {
-      await reviewService.deleteReview(reviewId.toString());
+			// 成功時はローカル状態から削除
+			setReviews(reviews.filter((review) => review.id !== reviewId));
 
-      // 成功時はローカル状態から削除
-      setReviews(reviews.filter((review) => review.id !== reviewId));
+			// 削除後はレビュー投稿フォームを表示
+			setShowReviewForm(true);
+			showToast("レビューを削除しました。", "success");
+		} catch (err) {
+			console.error("レビュー削除エラー:", err);
+			showToast(
+				getUserFacingErrorMessage(
+					err,
+					"レビューの削除に失敗しました。もう一度お試しください。",
+				),
+				"error",
+			);
+		}
+	};
 
-      // 削除後はレビュー投稿フォームを表示
-      setShowReviewForm(true);
-    } catch (err) {
-      console.error("レビュー削除エラー:", err);
-      alert("レビューの削除に失敗しました。もう一度お試しください。");
-    }
-  };
+	// ローディング状態
+	if (loading) {
+		return <QuestDetailSkeleton />;
+	}
 
-  // ローディング状態
-  if (loading) {
-    return <QuestDetailSkeleton />;
-  }
+	// エラー状態
+	if (error || !quest) {
+		return (
+			<div className="max-w-4xl mx-auto px-4 py-8">
+				<div className="bg-red-50 border border-red-200 rounded-xl p-6 text-center">
+					<div className="w-12 h-12 bg-red-500 rounded-full mx-auto mb-4 flex items-center justify-center">
+						<span className="text-white text-2xl">×</span>
+					</div>
+					<h2 className="text-xl font-bold text-red-800 mb-2">
+						{error || "クエストが見つかりません"}
+					</h2>
+					<p className="text-red-600">
+						クエストの情報を取得できませんでした。URLを確認してください。
+					</p>
+				</div>
+			</div>
+		);
+	}
 
-  // エラー状態
-  if (error || !quest) {
-    return (
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="bg-red-50 border border-red-200 rounded-xl p-6 text-center">
-          <div className="w-12 h-12 bg-red-500 rounded-full mx-auto mb-4 flex items-center justify-center">
-            <span className="text-white text-2xl">×</span>
-          </div>
-          <h2 className="text-xl font-bold text-red-800 mb-2">
-            {error || "クエストが見つかりません"}
-          </h2>
-          <p className="text-red-600">
-            クエストの情報を取得できませんでした。URLを確認してください。
-          </p>
-        </div>
-      </div>
-    );
-  }
+	// 完了していないクエストの場合はエラー表示
+	if (quest.status !== QuestStatus.Completed) {
+		return (
+			<div className="max-w-4xl mx-auto px-4 py-8">
+				<div className="bg-red-50 border border-red-200 rounded-xl p-6 text-center">
+					<div className="w-12 h-12 bg-red-500 rounded-full mx-auto mb-4 flex items-center justify-center">
+						<span className="text-white text-2xl">×</span>
+					</div>
+					<h2 className="text-xl font-bold text-red-800 mb-2">
+						レビューできません
+					</h2>
+					<p className="text-red-600">
+						このクエストはまだ完了していません。完了後にレビューを投稿できます。
+					</p>
+				</div>
+			</div>
+		);
+	}
 
-  // 完了していないクエストの場合はエラー表示
-  if (quest.status !== QuestStatus.Completed) {
-    return (
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="bg-red-50 border border-red-200 rounded-xl p-6 text-center">
-          <div className="w-12 h-12 bg-red-500 rounded-full mx-auto mb-4 flex items-center justify-center">
-            <span className="text-white text-2xl">×</span>
-          </div>
-          <h2 className="text-xl font-bold text-red-800 mb-2">
-            レビューできません
-          </h2>
-          <p className="text-red-600">
-            このクエストはまだ完了していません。完了後にレビューを投稿できます。
-          </p>
-        </div>
-      </div>
-    );
-  }
+	return (
+		<div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
+			{/* クエスト情報 */}
+			<div className="relative bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg p-6 border-2 border-amber-200 space-y-4">
+				<StatusRibbon
+					status={
+						quest.status === QuestStatus.Completed
+							? "completed"
+							: quest.status === QuestStatus.Active
+								? "participating"
+								: "applied"
+					}
+				/>
+				{quest.difficulty && (
+					<div
+						className={`absolute top-4 left-4 w-3 h-3 rounded-full ${getDifficultyColor(
+							quest.difficulty,
+						)}`}
+					/>
+				)}
 
-  return (
-    <div className="max-w-4xl mx-auto px-4 py-8 space-y-8">
-      {/* クエスト情報 */}
-      <div className="relative bg-gradient-to-br from-amber-50 to-amber-100 rounded-xl shadow-lg p-6 border-2 border-amber-200 space-y-4">
-        <StatusRibbon
-          status={
-            quest.status === QuestStatus.Completed
-              ? "completed"
-              : quest.status === QuestStatus.Active
-              ? "participating"
-              : "applied"
-          }
-        />
-        {quest.difficulty && (
-          <div
-            className={`absolute top-4 left-4 w-3 h-3 rounded-full ${getDifficultyColor(
-              quest.difficulty
-            )}`}
-          ></div>
-        )}
+				<h1 className="text-2xl font-bold text-slate-800">{quest.title}</h1>
+				<p className="text-slate-600">{quest.description}</p>
+				<div className="flex flex-wrap gap-2">
+					<Tag color="blue">{quest.type}</Tag>
+					{quest.tags?.map((tag) => (
+						<Tag key={tag} color="purple">
+							{tag}
+						</Tag>
+					))}
+				</div>
+			</div>
 
-        <h1 className="text-2xl font-bold text-slate-800">{quest.title}</h1>
-        <p className="text-slate-600">{quest.description}</p>
-        <div className="flex flex-wrap gap-2">
-          <Tag color="blue">{quest.type}</Tag>
-          {quest.tags &&
-            quest.tags.map((tag, index) => (
-              <Tag key={index} color="purple">
-                {tag}
-              </Tag>
-            ))}
-        </div>
-      </div>
-
-      {/* レビュー */}
-      <ReviewSection
-        reviews={reviews}
-        newReview={newReview}
-        setNewReview={setNewReview}
-        onSubmit={handleSubmitReview}
-        showReviewForm={showReviewForm}
-        onEditReview={handleEditReview}
-        onDeleteReview={handleDeleteReview}
-        currentUserId={currentUserId}
-      />
-    </div>
-  );
+			{/* レビュー */}
+			<ReviewSection
+				reviews={reviews}
+				newReview={newReview}
+				setNewReview={setNewReview}
+				onSubmit={handleSubmitReview}
+				showReviewForm={showReviewForm}
+				onEditReview={handleEditReview}
+				onDeleteReview={handleDeleteReview}
+				currentUserId={currentUserId}
+			/>
+		</div>
+	);
 };
 
 export default QuestDetailPage;

--- a/apps/frontend/src/components/providers/ToastProvider.tsx
+++ b/apps/frontend/src/components/providers/ToastProvider.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import { X } from "lucide-react";
+import {
+	createContext,
+	useCallback,
+	useContext,
+	useMemo,
+	useState,
+} from "react";
+import type React from "react";
+
+export type ToastType = "success" | "error" | "info";
+
+type Toast = {
+	id: number;
+	message: string;
+	type: ToastType;
+};
+
+type ToastContextValue = {
+	showToast: (message: string, type?: ToastType) => void;
+};
+
+const ToastContext = createContext<ToastContextValue>({
+	showToast: () => {},
+});
+
+const toastClassNames: Record<ToastType, string> = {
+	success: "border-emerald-300 bg-emerald-50 text-emerald-900",
+	error: "border-red-300 bg-red-50 text-red-900",
+	info: "border-blue-300 bg-blue-50 text-blue-900",
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+	const [toasts, setToasts] = useState<Toast[]>([]);
+
+	const dismissToast = useCallback((id: number) => {
+		setToasts((current) => current.filter((toast) => toast.id !== id));
+	}, []);
+
+	const showToast = useCallback(
+		(message: string, type: ToastType = "info") => {
+			const id = Date.now() + Math.random();
+			setToasts((current) => [...current, { id, message, type }]);
+			window.setTimeout(() => dismissToast(id), 4000);
+		},
+		[dismissToast],
+	);
+
+	const value = useMemo(() => ({ showToast }), [showToast]);
+
+	return (
+		<ToastContext.Provider value={value}>
+			{children}
+			<div
+				aria-live="polite"
+				aria-relevant="additions removals"
+				className="fixed right-4 top-4 z-[80] flex w-[calc(100vw-2rem)] max-w-sm flex-col gap-3"
+			>
+				{toasts.map((toast) => (
+					<output
+						key={toast.id}
+						className={`flex items-start gap-3 rounded-lg border px-4 py-3 text-sm shadow-lg ${toastClassNames[toast.type]}`}
+					>
+						<span className="min-w-0 flex-1">{toast.message}</span>
+						<button
+							type="button"
+							aria-label="通知を閉じる"
+							onClick={() => dismissToast(toast.id)}
+							className="rounded p-0.5 opacity-70 transition hover:opacity-100"
+						>
+							<X className="h-4 w-4" />
+						</button>
+					</output>
+				))}
+			</div>
+		</ToastContext.Provider>
+	);
+}
+
+export function useToast() {
+	return useContext(ToastContext);
+}

--- a/apps/frontend/src/hooks/useMyPageData.ts
+++ b/apps/frontend/src/hooks/useMyPageData.ts
@@ -1,152 +1,162 @@
-import { useEffect, useState } from "react";
+import { useToast } from "@/components/providers/ToastProvider";
+import { getUserFacingErrorMessage } from "@/services/apiError";
 import { authenticatedHttpRequest } from "@/services/httpClient";
 import { questService } from "@/services/quest";
 import type { Quest } from "@quest-board/types";
+import { useEffect, useState } from "react";
 
 type QuestEntry = { id: number };
 
 export type MyPageQuestEntries = {
-  participating: QuestEntry[];
-  completed: QuestEntry[];
-  applied: QuestEntry[];
+	participating: QuestEntry[];
+	completed: QuestEntry[];
+	applied: QuestEntry[];
 };
 
 type ApiNotification = {
-  id: number;
-  message: string;
-  isRead: boolean;
-  createdAt: string;
+	id: number;
+	message: string;
+	isRead: boolean;
+	createdAt: string;
 };
 
 export type DisplayNotification = {
-  id: number;
-  message: string;
-  type: "success" | "reward" | "info";
-  timestamp: string;
+	id: number;
+	message: string;
+	type: "success" | "reward" | "info";
+	timestamp: string;
 };
 
 export type MyPageQuestGroups = {
-  participating: Quest[];
-  completed: Quest[];
-  applied: Quest[];
+	participating: Quest[];
+	completed: Quest[];
+	applied: Quest[];
 };
 
 export const emptyQuestEntries = (): MyPageQuestEntries => ({
-  participating: [],
-  completed: [],
-  applied: [],
+	participating: [],
+	completed: [],
+	applied: [],
 });
 
 export const emptyQuestGroups = (): MyPageQuestGroups => ({
-  participating: [],
-  completed: [],
-  applied: [],
+	participating: [],
+	completed: [],
+	applied: [],
 });
 
 export const toDisplayNotification = (
-  notification: ApiNotification
+	notification: ApiNotification,
 ): DisplayNotification => ({
-  id: notification.id,
-  message: notification.message,
-  type: "info",
-  timestamp: new Date(notification.createdAt).toLocaleString("ja-JP"),
+	id: notification.id,
+	message: notification.message,
+	type: "info",
+	timestamp: new Date(notification.createdAt).toLocaleString("ja-JP"),
 });
 
 export const categorizeQuestsByStatus = (
-  quests: Quest[]
+	quests: Quest[],
 ): MyPageQuestGroups => {
-  const groups = emptyQuestGroups();
+	const groups = emptyQuestGroups();
 
-  quests.forEach((quest) => {
-    const status = String(quest.status || "").toLowerCase();
-    if (status === "active" || status === "in_progress") {
-      groups.participating.push(quest);
-      return;
-    }
+	for (const quest of quests) {
+		const status = String(quest.status || "").toLowerCase();
+		if (status === "active" || status === "in_progress") {
+			groups.participating.push(quest);
+			continue;
+		}
 
-    if (status === "completed") {
-      groups.completed.push(quest);
-      return;
-    }
+		if (status === "completed") {
+			groups.completed.push(quest);
+			continue;
+		}
 
-    groups.applied.push(quest);
-  });
+		groups.applied.push(quest);
+	}
 
-  return groups;
+	return groups;
 };
 
 export const useMyPageData = () => {
-  const [entries, setEntries] = useState<MyPageQuestEntries>(emptyQuestEntries);
-  const [notifications, setNotifications] = useState<DisplayNotification[]>([]);
-  const [questGroups, setQuestGroups] =
-    useState<MyPageQuestGroups>(emptyQuestGroups);
+	const { showToast } = useToast();
+	const [entries, setEntries] = useState<MyPageQuestEntries>(emptyQuestEntries);
+	const [notifications, setNotifications] = useState<DisplayNotification[]>([]);
+	const [questGroups, setQuestGroups] =
+		useState<MyPageQuestGroups>(emptyQuestGroups);
 
-  useEffect(() => {
-    let cancelled = false;
+	useEffect(() => {
+		let cancelled = false;
 
-    const fetchMyPageData = async () => {
-      try {
-        const [entryResponse, notificationResponse] = await Promise.all([
-          authenticatedHttpRequest<MyPageQuestEntries>({
-            method: "GET",
-            path: "/mypage/entries",
-          }),
-          authenticatedHttpRequest<ApiNotification[]>({
-            method: "GET",
-            path: "/mypage/notifications",
-          }),
-        ]);
+		const fetchMyPageData = async () => {
+			try {
+				const [entryResponse, notificationResponse] = await Promise.all([
+					authenticatedHttpRequest<MyPageQuestEntries>({
+						method: "GET",
+						path: "/mypage/entries",
+					}),
+					authenticatedHttpRequest<ApiNotification[]>({
+						method: "GET",
+						path: "/mypage/notifications",
+					}),
+				]);
 
-        if (cancelled) {
-          return;
-        }
+				if (cancelled) {
+					return;
+				}
 
-        const nextEntries = entryResponse || emptyQuestEntries();
-        setEntries(nextEntries);
+				const nextEntries = entryResponse || emptyQuestEntries();
+				setEntries(nextEntries);
 
-        const questIds = Array.from(
-          new Set([
-            ...nextEntries.participating.map((quest) => quest.id),
-            ...nextEntries.completed.map((quest) => quest.id),
-            ...nextEntries.applied.map((quest) => quest.id),
-          ])
-        );
+				const questIds = Array.from(
+					new Set([
+						...nextEntries.participating.map((quest) => quest.id),
+						...nextEntries.completed.map((quest) => quest.id),
+						...nextEntries.applied.map((quest) => quest.id),
+					]),
+				);
 
-        const allQuests = await questService.getAllQuests();
-        if (cancelled) {
-          return;
-        }
+				const allQuests = await questService.getAllQuests();
+				if (cancelled) {
+					return;
+				}
 
-        const relatedQuests = allQuests.filter((quest) =>
-          questIds.includes(quest.id)
-        );
+				const relatedQuests = allQuests.filter((quest) =>
+					questIds.includes(quest.id),
+				);
 
-        setQuestGroups(categorizeQuestsByStatus(relatedQuests));
-        setNotifications(
-          Array.isArray(notificationResponse)
-            ? notificationResponse.map(toDisplayNotification)
-            : []
-        );
-      } catch (error) {
-        console.error("/mypage データ取得に失敗しました", error);
-        if (!cancelled) {
-          setEntries(emptyQuestEntries());
-          setNotifications([]);
-          setQuestGroups(emptyQuestGroups());
-        }
-      }
-    };
+				setQuestGroups(categorizeQuestsByStatus(relatedQuests));
+				setNotifications(
+					Array.isArray(notificationResponse)
+						? notificationResponse.map(toDisplayNotification)
+						: [],
+				);
+			} catch (error) {
+				console.error("/mypage データ取得に失敗しました", error);
+				if (!cancelled) {
+					setEntries(emptyQuestEntries());
+					setNotifications([]);
+					setQuestGroups(emptyQuestGroups());
+					showToast(
+						getUserFacingErrorMessage(
+							error,
+							"マイページのデータ取得に失敗しました。",
+						),
+						"error",
+					);
+				}
+			}
+		};
 
-    fetchMyPageData();
+		fetchMyPageData();
 
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+		return () => {
+			cancelled = true;
+		};
+	}, [showToast]);
 
-  return {
-    entries,
-    notifications,
-    questGroups,
-  };
+	return {
+		entries,
+		notifications,
+		questGroups,
+	};
 };

--- a/apps/frontend/src/services/apiError.ts
+++ b/apps/frontend/src/services/apiError.ts
@@ -3,14 +3,24 @@
  * - apps/backend/src/middlewares/errorHandler.ts と対応
  */
 export interface ApiErrorResponse {
-  success: false;
-  error: string;
-  code: string;
-  details?: Array<{
-    field?: string;
-    message: string;
-  }>;
+	success: false;
+	error: string;
+	code: ApiErrorCode | string;
+	details?: Array<{
+		field?: string;
+		message: string;
+	}>;
 }
+
+export type ApiErrorCode =
+	| "UNAUTHORIZED"
+	| "FORBIDDEN"
+	| "NOT_FOUND"
+	| "VALIDATION_ERROR"
+	| "CONFLICT"
+	| "INTERNAL_SERVER_ERROR"
+	| "NETWORK_ERROR"
+	| "UNKNOWN_ERROR";
 
 /**
  * バックエンドの標準エラーレスポンスをラップするエラークラス
@@ -31,51 +41,138 @@ export interface ApiErrorResponse {
  * ```
  */
 export class ApiError extends Error {
-  /** バックエンドのエラーコード (例: "UNAUTHORIZED", "NOT_FOUND") */
-  readonly code: string;
-  /** HTTP ステータスコード */
-  readonly status: number;
-  /** バックエンドが返したフィールドレベルの詳細エラー */
-  readonly details: ApiErrorResponse["details"];
+	/** バックエンドのエラーコード (例: "UNAUTHORIZED", "NOT_FOUND") */
+	readonly code: ApiErrorCode | string;
+	/** HTTP ステータスコード */
+	readonly status: number;
+	/** バックエンドが返したフィールドレベルの詳細エラー */
+	readonly details: ApiErrorResponse["details"];
 
-  constructor(
-    message: string,
-    code: string,
-    status: number,
-    details?: ApiErrorResponse["details"]
-  ) {
-    super(message);
-    this.name = "ApiError";
-    this.code = code;
-    this.status = status;
-    this.details = details;
-  }
+	constructor(
+		message: string,
+		code: ApiErrorCode | string,
+		status: number,
+		details?: ApiErrorResponse["details"],
+	) {
+		super(message);
+		this.name = "ApiError";
+		this.code = code;
+		this.status = status;
+		this.details = details;
+	}
 
-  /** 認証エラーかどうかを判定 */
-  isUnauthorized(): boolean {
-    return this.status === 401;
-  }
+	/** 認証エラーかどうかを判定 */
+	isUnauthorized(): boolean {
+		return this.status === 401;
+	}
 
-  /** バリデーションエラーかどうかを判定 */
-  isValidationError(): boolean {
-    return this.code === "VALIDATION_ERROR";
-  }
+	/** バリデーションエラーかどうかを判定 */
+	isValidationError(): boolean {
+		return this.code === "VALIDATION_ERROR";
+	}
 
-  /** 404 Not Found かどうかを判定 */
-  isNotFound(): boolean {
-    return this.status === 404;
-  }
+	/** 404 Not Found かどうかを判定 */
+	isNotFound(): boolean {
+		return this.status === 404;
+	}
 }
 
 /**
  * レスポンスボディが ApiErrorResponse かどうかを判定するタイプガード
  */
 export function isApiErrorResponse(body: unknown): body is ApiErrorResponse {
-  return (
-    typeof body === "object" &&
-    body !== null &&
-    (body as ApiErrorResponse).success === false &&
-    typeof (body as ApiErrorResponse).error === "string" &&
-    typeof (body as ApiErrorResponse).code === "string"
-  );
+	return (
+		typeof body === "object" &&
+		body !== null &&
+		(body as ApiErrorResponse).success === false &&
+		typeof (body as ApiErrorResponse).error === "string" &&
+		typeof (body as ApiErrorResponse).code === "string"
+	);
+}
+
+export function isAuthRequiredError(error: unknown): boolean {
+	return (
+		error instanceof ApiError &&
+		(error.status === 401 ||
+			error.status === 403 ||
+			error.code === "UNAUTHORIZED" ||
+			error.code === "FORBIDDEN")
+	);
+}
+
+export function getValidationFieldErrors(
+	error: unknown,
+): Record<string, string> {
+	if (!(error instanceof ApiError) || !error.isValidationError()) {
+		return {};
+	}
+
+	return (error.details ?? []).reduce<Record<string, string>>((acc, detail) => {
+		if (detail.field) {
+			acc[detail.field] = detail.message;
+		}
+		return acc;
+	}, {});
+}
+
+export function getUserFacingErrorMessage(
+	error: unknown,
+	fallback = "エラーが発生しました。時間をおいて再度お試しください。",
+): string {
+	if (error instanceof ApiError) {
+		if (error.code === "UNAUTHORIZED" || error.status === 401) {
+			return "ログインが必要です。";
+		}
+		if (error.code === "FORBIDDEN" || error.status === 403) {
+			return "この操作を行う権限がありません。";
+		}
+		if (error.code === "NOT_FOUND" || error.status === 404) {
+			return "対象のデータが見つかりません。";
+		}
+		if (error.code === "VALIDATION_ERROR" || error.status === 400) {
+			return error.message || "入力内容を確認してください。";
+		}
+		if (error.code === "CONFLICT" || error.status === 409) {
+			return error.message || "既に処理済み、または競合が発生しました。";
+		}
+		if (error.code === "INTERNAL_SERVER_ERROR" || error.status >= 500) {
+			return "サーバーで問題が発生しました。時間をおいて再度お試しください。";
+		}
+		return error.message || fallback;
+	}
+
+	if (error instanceof TypeError && error.message === "Failed to fetch") {
+		return "ネットワークに接続できません。通信状況を確認してください。";
+	}
+
+	if (error instanceof Error) {
+		const maybeCode = (error as { code?: unknown }).code;
+		if (typeof maybeCode === "string") {
+			if (maybeCode === "auth/email-already-in-use") {
+				return "このメールアドレスはすでに登録されています。";
+			}
+			if (maybeCode === "auth/invalid-email") {
+				return "メールアドレスの形式が正しくありません。";
+			}
+			if (maybeCode === "auth/weak-password") {
+				return "パスワードは6文字以上で入力してください。";
+			}
+			if (
+				maybeCode === "auth/invalid-credential" ||
+				maybeCode === "auth/user-not-found" ||
+				maybeCode === "auth/wrong-password"
+			) {
+				return "メールアドレスまたはパスワードが正しくありません。";
+			}
+			if (maybeCode === "auth/network-request-failed") {
+				return "ネットワークに接続できません。通信状況を確認してください。";
+			}
+		}
+
+		if (error.message === "User not authenticated") {
+			return "ログインが必要です。";
+		}
+	}
+
+	return fallback;
 }

--- a/apps/frontend/src/services/httpClient.ts
+++ b/apps/frontend/src/services/httpClient.ts
@@ -1,6 +1,6 @@
 import { API_CONFIG } from "../constants/config";
-import { getIdToken } from "./auth/googleAuth";
 import { ApiError, isApiErrorResponse } from "./apiError";
+import { getIdToken } from "./auth/googleAuth";
 
 export type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
 
@@ -80,11 +80,15 @@ export async function httpRequest<TResponse = unknown, TBody = unknown>(
 			const legacyBody = errorBody as LegacyErrorResponseBody | null;
 			const message =
 				legacyBody?.error || legacyBody?.message || res.statusText;
-			throw new Error(`HTTP ${res.status}: ${message}`);
+			throw new ApiError(message, getCodeForStatus(res.status), res.status);
 		}
 
 		const text = await res.text().catch(() => "");
-		throw new Error(`HTTP ${res.status}: ${text || res.statusText}`);
+		throw new ApiError(
+			text || res.statusText,
+			getCodeForStatus(res.status),
+			res.status,
+		);
 	}
 
 	const contentType = res.headers.get("content-type") || "";
@@ -100,7 +104,7 @@ export async function authenticatedHttpRequest<
 >(options: RequestOptions<TBody>): Promise<TResponse> {
 	const idToken = getIdToken();
 	if (!idToken) {
-		throw new Error("User not authenticated");
+		throw new ApiError("User not authenticated", "UNAUTHORIZED", 401);
 	}
 
 	return httpRequest<TResponse, TBody>({
@@ -124,6 +128,15 @@ export const apiClient = {
 	delete: <TResponse>(path: string) =>
 		httpRequest<TResponse>({ path, method: "DELETE" }),
 };
+
+function getCodeForStatus(status: number) {
+	if (status === 401) return "UNAUTHORIZED";
+	if (status === 403) return "FORBIDDEN";
+	if (status === 404) return "NOT_FOUND";
+	if (status === 409) return "CONFLICT";
+	if (status >= 500) return "INTERNAL_SERVER_ERROR";
+	return "UNKNOWN_ERROR";
+}
 
 export const authenticatedApiClient = {
 	get: <TResponse>(path: string, query?: RequestOptions["query"]) =>


### PR DESCRIPTION
## Summary
- フロントエンド共通の `ToastProvider` / `useToast` と `ApiError` 分類ヘルパーを追加
- `alert` や HTTP 文字列判定を toast と `status` / `code` ベースの分類へ置換
- API validation details を `QuestEditorForm` の field error に反映
- バックエンドのレビュー重複、ロール不正、ユーザー未存在、クエスト参加失敗を標準 `AppError` に統一

## Verification
- `pnpm exec biome check <変更対象26ファイル>`
- `pnpm --filter frontend test`
- `pnpm --filter backend test`
- `pnpm --filter frontend build`

## Notes
- `pnpm lint` は既存の `apps/backend/tsconfig.json`、`apps/e2e/tsconfig.json`、backend test mocks など今回差分外のフォーマット指摘で失敗します。変更対象ファイルに限定した Biome check は成功しています。
- 新規 clone/worktree 環境では `prisma generate` が sandbox のホーム配下 cache 書き込み制限で失敗したため、生成済み Prisma Client を同期して backend test を実行しました。
